### PR TITLE
[G2M] Legend - custom labels on bottom legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Legend - right / column legend hides when chart width exceeds legend heigth
+
+### Added
+- Legend - custom number of labels allowed on the bottom / row chart Legend
+
 ## [0.2.0] - 2020-07-07
 
 ### Added

--- a/src/components/bar-chart/index.js
+++ b/src/components/bar-chart/index.js
@@ -40,6 +40,7 @@ const BarChart = ({
   // must be supplied together
   groupByKey,
   valueKey,
+  maxRowLegendItems,
   ...nivoProps
 }) => {
   // a single key is required for the X axis scale
@@ -123,6 +124,7 @@ const BarChart = ({
         axisBottomLabelCount,
         lastXAxisTickLabelWidth,
         maxYAxisTickLabelWidth,
+        maxRowLegendItems
       })}
     />
   )

--- a/src/components/line-chart/index.js
+++ b/src/components/line-chart/index.js
@@ -63,6 +63,7 @@ const ResponsiveLineChart = ({
   yScale,
   width,
   height,
+  maxRowLegendItems,
   ...nivoProps
 }) => {
   const { finalIndexBy, finalXKey, finalYKeys } = processSeriesDataKeys({ data, indexBy, xKey, yKeys, indexByValue })
@@ -145,6 +146,7 @@ const ResponsiveLineChart = ({
           lastXAxisTickLabelWidth,
           axisLeftLabelDisplayFn,
           maxYAxisTickLabelWidth,
+          maxRowLegendItems
         })}
       >
       </ResponsiveLine>

--- a/src/components/pie-chart/index.js
+++ b/src/components/pie-chart/index.js
@@ -54,6 +54,7 @@ const PieChart = ({
   height,
   enableSlicesLabels,
   slicesLabelsSkipAngle,
+  maxRowLegendItems,
   ...nivoProps
 }) => {
   // indexBy => id
@@ -122,6 +123,7 @@ const PieChart = ({
         height,
         width,
         dash: true,
+        maxRowLegendItems
       })}
     >
     </ResponsivePie>

--- a/src/components/scatter-chart/index.js
+++ b/src/components/scatter-chart/index.js
@@ -45,6 +45,7 @@ const ScatterChart = ({
   xScale,
   axisLeftLegendLabel,
   yScale,
+  maxRowLegendItems,
   width,
   height,
   ...nivoProps
@@ -114,6 +115,7 @@ const ScatterChart = ({
         lastXAxisTickLabelWidth,
         axisLeftLabelDisplayFn,
         maxYAxisTickLabelWidth,
+        maxRowLegendItems
       })}
     />
   )

--- a/src/shared/constants/chart-props.js
+++ b/src/shared/constants/chart-props.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types'
 
+import { MAX_LEGEND_ITEMS_ROW } from './dimensions'
+
 
 export const chartPropTypes = {
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -22,6 +24,7 @@ export const chartPropTypes = {
   axisLeftLabelDisplayFn: PropTypes.func,
   width: PropTypes.number,
   height: PropTypes.number,
+  maxRowLegendItems: PropTypes.number
 }
 
 export const chartDefaultProps = {
@@ -38,6 +41,7 @@ export const chartDefaultProps = {
   axisLeftLabelDisplayFn: d => d,
   width: 100,
   height: 100,
+  maxRowLegendItems: MAX_LEGEND_ITEMS_ROW
 }
 
 export const seriesPropTypes = {

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -21,8 +21,7 @@ import {
   LEGEND_TRANSLATE_Y,
   TRIMMED_LEGEND_WIDTH,
   LEGEND_COLUMN_FIXED_ELEMENTS_WIDTH,
-  LEGEND_ROW_FIXED_ELEMENTS_WIDTH,
-  MAX_LEGEND_ITEMS_ROW
+  LEGEND_ROW_FIXED_ELEMENTS_WIDTH
 } from '../constants/dimensions'
 import designSystemColors, { hues, lightnesses } from '../constants/design-system-colors'
 
@@ -53,7 +52,8 @@ const setChartMargin = (
   maxLegendLabelWidth,
   legendItemCount,
   maxYAxisTickLabelWidth,
-  lastXAxisTickLabelWidth
+  lastXAxisTickLabelWidth,
+  maxRowLegendItems
 ) => {
   // default values
   /**
@@ -130,7 +130,7 @@ const setChartMargin = (
 
   // show right column legend when in landscape mode and number of legend items surpass MAX_LEGEND_ITEMS_ROW
   const rightHandLegend = isAspectRatio(width, height, aspectRatios.LANDSCAPE)
-                          || legendItemCount > MAX_LEGEND_ITEMS_ROW
+                          || legendItemCount > maxRowLegendItems
   // calculate height of column legend to hide it if it is larger than chart height
   const columnLegendHeight = legendItemCount * LEGEND_HEIGHT
   /**
@@ -341,7 +341,8 @@ export const getCommonProps = ({
   axisLeftLabelDisplayFn = d => d,
   maxYAxisTickLabelWidth = 0,
   dash, // not for pie?
-  legendProps = {},
+  legendProps={},
+  maxRowLegendItems
 }) => {
   const maxLegendLabelWidth = getLegendLabelMaxWidth(keys)
   const legendItemCount = keys.length
@@ -367,7 +368,8 @@ export const getCommonProps = ({
     maxLegendLabelWidth,
     legendItemCount,
     maxYAxisTickLabelWidth,
-    lastXAxisTickLabelWidth
+    lastXAxisTickLabelWidth,
+    maxRowLegendItems
   )
 
   const chartWidth = width - margin.right - margin.left

--- a/src/stories/line.stories.js
+++ b/src/stories/line.stories.js
@@ -22,6 +22,21 @@ storiesOf('Line Chart', module)
       />
     </ResponsiveChartWrapper>
   ))
+  .add('Widget Line Chart with custom bottom legend label numbers', () => (
+    <ResponsiveChartWrapper>
+      <LineChart
+        title='Test'
+        data={lineChartData}
+        indexBy='country'
+        xKey='vehicle'
+        yKey='amount'
+        xScale={{ type: 'point' }}
+        axisBottomLegendLabel={'axisBottomLegend'}
+        axisLeftLegendLabel={'axisLeftLegend'}
+        maxRowLegendItems={ 4 }
+      />
+    </ResponsiveChartWrapper>
+  ))
   .add('Index By Keys', () => (
     <ResponsiveChartWrapper>
       <LineChart

--- a/src/stories/pie.stories.js
+++ b/src/stories/pie.stories.js
@@ -29,6 +29,16 @@ storiesOf('Pie Chart', module)
       <PieChart title='My Title' data={pieChartData} isDonut={false} slicesLabelsSkipAngle={ 200 } />
     </ResponsiveChartWrapper>
   ))
+  .add('Widget Pie Chart with custom bottom legend label numbers', () => (
+    <ResponsiveChartWrapper>
+      <PieChart
+        title='My Title'
+        data={pieChartData}
+        isDonut={false}
+        maxRowLegendItems={ 4 }
+      />
+    </ResponsiveChartWrapper>
+  ))
   .add('Visit Data', () => (
     <ResponsiveChartWrapper>
       <PieChart title='Visits' data={barChartData} isDonut={false} />


### PR DESCRIPTION
Enables custom nr of bottom legend items / labels
Closes #73 

- CHANGELOG.md: added 'Changed' and 'Added' sections for Unreleased
- bar-chart/index.js, line-chart/index.js, pie-chart/index.js, scatter-chart/index.js: added legendProps in chart props and getCommonProps
- line.stories.js, pie.stories.js: added stories to demonstrate custom labels on bottom legend
- chart-props.js: imported MAX_LEGEND_ITEMS_ROW
- chart-props.js: added legendProps in chartPropTypes and chartDefaultProps
- utils/index.js: deleted imported MAX_LEGEND_ITEMS_ROW
- utils/index.js: deleted default {} value for legendProps
- utils/index.js: added legendProps to getCommonProps and setChartMargin
- utils/index.js: defined maxRowLegendItems and used it in setting the rightHandLegend