### PR TITLE
Legend - add custom trim prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Legend - right / column legend hides when chart width exceeds legend heigth
 
 ### Added
-- Legend - custom number of labels allowed on the bottom / row chart Legend
+- Legend - custom number of labels allowed on the bottom / row chart legend
+- Legend - custom trimLegend prop to allow trimming or not of chart legend labels
 
 ## [0.2.0] - 2020-07-07
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ A catch-all `{...nivoProps}` is passed along to each chart, though the values mi
 - **axisBottomDisplayFn** - `labelValue => { ...return displayValue }` - function to customize the bottom axis tick labels. Default is `d => d`
 - **axisLeftLegendLabel** - the label for the left axis
 - **axisBottomDisplayFn** - `labelValue => { ...return displayValue }` - function to customize the left axis tick labels. Default is `d => d`
+- **maxRowLegendItems** - maximum labels on the bottom / row chart legend. Default is MAX_LEGEND_ITEMS_ROW (3)
+- **trimLegend** - whether or not to trim chart legend labels. Default is `true` 
 
 #### Bar, Line and Scatter:
 - **axisBottomOrder** - how to define the order of bottom axis labels for a Bar Chart or 'point' scale. Either `[]` of specific values or `asc`/`desc` to sort the data. If an array is provided, data will be filtered based on the provided keys. 

--- a/src/components/bar-chart/index.js
+++ b/src/components/bar-chart/index.js
@@ -41,6 +41,7 @@ const BarChart = ({
   groupByKey,
   valueKey,
   maxRowLegendItems,
+  trimLegend,
   ...nivoProps
 }) => {
   // a single key is required for the X axis scale
@@ -124,7 +125,8 @@ const BarChart = ({
         axisBottomLabelCount,
         lastXAxisTickLabelWidth,
         maxYAxisTickLabelWidth,
-        maxRowLegendItems
+        maxRowLegendItems,
+        trimLegend
       })}
     />
   )

--- a/src/components/line-chart/index.js
+++ b/src/components/line-chart/index.js
@@ -64,6 +64,7 @@ const ResponsiveLineChart = ({
   width,
   height,
   maxRowLegendItems,
+  trimLegend,
   ...nivoProps
 }) => {
   const { finalIndexBy, finalXKey, finalYKeys } = processSeriesDataKeys({ data, indexBy, xKey, yKeys, indexByValue })
@@ -146,7 +147,8 @@ const ResponsiveLineChart = ({
           lastXAxisTickLabelWidth,
           axisLeftLabelDisplayFn,
           maxYAxisTickLabelWidth,
-          maxRowLegendItems
+          maxRowLegendItems,
+          trimLegend
         })}
       >
       </ResponsiveLine>

--- a/src/components/pie-chart/index.js
+++ b/src/components/pie-chart/index.js
@@ -55,6 +55,7 @@ const PieChart = ({
   enableSlicesLabels,
   slicesLabelsSkipAngle,
   maxRowLegendItems,
+  trimLegend,
   ...nivoProps
 }) => {
   // indexBy => id
@@ -123,7 +124,8 @@ const PieChart = ({
         height,
         width,
         dash: true,
-        maxRowLegendItems
+        maxRowLegendItems,
+        trimLegend
       })}
     >
     </ResponsivePie>

--- a/src/components/scatter-chart/index.js
+++ b/src/components/scatter-chart/index.js
@@ -46,6 +46,7 @@ const ScatterChart = ({
   axisLeftLegendLabel,
   yScale,
   maxRowLegendItems,
+  trimLegend,
   width,
   height,
   ...nivoProps
@@ -115,7 +116,8 @@ const ScatterChart = ({
         lastXAxisTickLabelWidth,
         axisLeftLabelDisplayFn,
         maxYAxisTickLabelWidth,
-        maxRowLegendItems
+        maxRowLegendItems,
+        trimLegend
       })}
     />
   )

--- a/src/shared/constants/chart-props.js
+++ b/src/shared/constants/chart-props.js
@@ -24,7 +24,8 @@ export const chartPropTypes = {
   axisLeftLabelDisplayFn: PropTypes.func,
   width: PropTypes.number,
   height: PropTypes.number,
-  maxRowLegendItems: PropTypes.number
+  maxRowLegendItems: PropTypes.number,
+  trimLegend: PropTypes.bool
 }
 
 export const chartDefaultProps = {
@@ -41,7 +42,8 @@ export const chartDefaultProps = {
   axisLeftLabelDisplayFn: d => d,
   width: 100,
   height: 100,
-  maxRowLegendItems: MAX_LEGEND_ITEMS_ROW
+  maxRowLegendItems: MAX_LEGEND_ITEMS_ROW,
+  trimLegend: true
 }
 
 export const seriesPropTypes = {

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -53,7 +53,8 @@ const setChartMargin = (
   legendItemCount,
   maxYAxisTickLabelWidth,
   lastXAxisTickLabelWidth,
-  maxRowLegendItems
+  maxRowLegendItems,
+  trimLegend
 ) => {
   // default values
   /**
@@ -159,13 +160,15 @@ const setChartMargin = (
       legendTranslate = LEGEND_TRANSLATE_X
       const expandingLabelContainer = width - WIDTH_BREAKPOINT_3 - LEGEND_COLUMN_FIXED_ELEMENTS_WIDTH - legendTranslate
       legendLabelContainerWidth = Math.max(expandingLabelContainer, TRIMMED_LEGEND_WIDTH)
-      if (expandingLabelContainer >= maxLegendLabelWidth) {
+      if (expandingLabelContainer >= maxLegendLabelWidth || !trimLegend) {
         legendLabelContainerWidth = maxLegendLabelWidth
       }
       right = legendLabelContainerWidth + legendTranslate + LEGEND_COLUMN_FIXED_ELEMENTS_WIDTH
     } else {
       legendItemWidth = (width - right - left) / legendItemCount
-      legendLabelContainerWidth = legendItemWidth - LEGEND_ROW_FIXED_ELEMENTS_WIDTH
+      legendLabelContainerWidth = trimLegend
+        ? legendItemWidth - LEGEND_ROW_FIXED_ELEMENTS_WIDTH
+        : maxLegendLabelWidth
       // adjust bottom to include legend and a buffer
       bottom += LEGEND_HEIGHT + BUFFER
     }
@@ -342,7 +345,8 @@ export const getCommonProps = ({
   maxYAxisTickLabelWidth = 0,
   dash, // not for pie?
   legendProps={},
-  maxRowLegendItems
+  maxRowLegendItems,
+  trimLegend
 }) => {
   const maxLegendLabelWidth = getLegendLabelMaxWidth(keys)
   const legendItemCount = keys.length
@@ -369,7 +373,8 @@ export const getCommonProps = ({
     legendItemCount,
     maxYAxisTickLabelWidth,
     lastXAxisTickLabelWidth,
-    maxRowLegendItems
+    maxRowLegendItems,
+    trimLegend
   )
 
   const chartWidth = width - margin.right - margin.left

--- a/src/stories/scatter.stories.js
+++ b/src/stories/scatter.stories.js
@@ -20,7 +20,6 @@ storiesOf('ScatterChart', module)
   .add('Widget Scatter Chart with no title', () => (
     <ResponsiveChartWrapper>
       <ScatterChart
-        title=''
         data={scatterChartData}
         axisBottomLegendLabel={'axisBottomLegend'}
         axisLeftLegendLabel={'axisLeftLegend'}
@@ -37,3 +36,15 @@ storiesOf('ScatterChart', module)
       />
     </ResponsiveChartWrapper>
   ))
+  .add('Widget Scatter Chart with no trimming of Legend', () => (
+    <ResponsiveChartWrapper>
+      <ScatterChart
+        title='My Title'
+        data={scatterChartData}
+        axisBottomLegendLabel={'axisBottomLegend'}
+        axisLeftLegendLabel={'axisLeftLegend'}
+        trimLegend={false}
+      />
+    </ResponsiveChartWrapper>
+  ))
+


### PR DESCRIPTION
Adds custom legendTrim prop to allow disabling of trimming functionality for chart legend labels

- updated CHANGELOG and Readme files with maxRowLegendItems and trimLegend props
- added prop trimLegend to all chart props and getCommonProps functions
- chart-props.js: added trimLegend to chartPropTypes, chartDefaultProps
- utils/index.js: added trimLegend to getCommonProps, setChartMargin
- utils/index.js: added trimLegend logic in setChartMargin for legendLabelContainerWidth
- scatter.stories.js: added story with legendTrim prop set to false