### PR TITLE
Y axis legend - fix offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Y axis legend - offset is calculated using the longest y axis tick value
+
 ## [0.3.0] - 2020-08-05
 
 ### Added

--- a/src/components/bar-chart/index.js
+++ b/src/components/bar-chart/index.js
@@ -60,7 +60,7 @@ const BarChart = ({
   const {
     xLabelCount: axisBottomLabelCount,
     lastXLabelWidth: lastXAxisTickLabelWidth,
-    lastYLabelWidth: maxYAxisTickLabelWidth,
+    maxYLabelWidth: maxYAxisTickLabelWidth,
   } = useMemo(() => getAxisLabelsBar({
     width,
     height,

--- a/src/components/line-chart/index.js
+++ b/src/components/line-chart/index.js
@@ -81,7 +81,7 @@ const ResponsiveLineChart = ({
   const {
     xLabelCount: axisBottomLabelCount,
     lastXLabelWidth: lastXAxisTickLabelWidth,
-    lastYLabelWidth: maxYAxisTickLabelWidth,
+    maxYLabelWidth: maxYAxisTickLabelWidth,
   } = useMemo(
     () => getAxisLabelsSeries({
       data: finalData,

--- a/src/components/scatter-chart/index.js
+++ b/src/components/scatter-chart/index.js
@@ -66,7 +66,7 @@ const ScatterChart = ({
   const {
     xLabelCount: axisBottomLabelCount,
     lastXLabelWidth: lastXAxisTickLabelWidth,
-    lastYLabelWidth: maxYAxisTickLabelWidth,
+    maxYLabelWidth: maxYAxisTickLabelWidth,
   } = useMemo(
     () => getAxisLabelsSeries({
       data: finalData,

--- a/src/shared/data/scatter-chart-data.js
+++ b/src/shared/data/scatter-chart-data.js
@@ -19,7 +19,7 @@ const scatterChartData = [
   { id: 'Third Legend Longer', x: 50, y: 0.575 },
   { id: 'Third Legend Longer', x: 60, y: 0.6 },
   { id: 'Third Legend Longer', x: 70, y: 0.550 },
-  { id: 'Third Legend Longer', x: 80, y: 0.9 },
+  { id: 'Third Legend Longer', x: 80, y: 1 },
   // { id: 'Fourth Legend', x: 20, y: 0.2 },
   // { id: 'Fourth Legend', x: 30, y: 0.425 },
   // { id: 'Fourth Legend', x: 40, y: 0.375 },

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -43,6 +43,8 @@ import LegendCircle from '../../components/legend-symbol'
  * @param { number } legendItemCount - number of items in the legend
  * @param { number } maxYAxisTickLabelWidth - the length of the maximum y-axis label value
  * @param { number } lastXAxisTickLabelWidth - the length of the highest x-axis label value
+ * @param { number } maxRowLegendItems - number of legend items to display on the bottom chart legend
+ * @param { boolean } trimLegend - to trim or not the legend items
  * @returns { object } - top, right, bottom, left margin values
  */
 const setChartMargin = (
@@ -210,7 +212,7 @@ export const getAxisLabelsBar = ({
     xLabelCount: xLabels.length,
     lastXLabelWidth: getTextSize(axisBottomLabelDisplayFn(xLabels[xLabels.length - 1])),
     yLabelCount: yLabels.length,
-    lastYLabelWidth: getTextSize(axisLeftLabelDisplayFn(yLabels[yLabels.length - 1])),
+    maxYLabelWidth: getLabelMaxWidth(yLabels,axisLeftLabelDisplayFn),
   }
 }
 
@@ -232,17 +234,18 @@ export const getAxisLabelsSeries = ({
     xLabelCount: xLabels.length,
     lastXLabelWidth: getTextSize(axisBottomLabelDisplayFn(xLabels[xLabels.length - 1])),
     yLabelCount: yLabels.length,
-    lastYLabelWidth: getTextSize(axisLeftLabelDisplayFn(yLabels[yLabels.length - 1])),
+    maxYLabelWidth: getLabelMaxWidth(yLabels,axisLeftLabelDisplayFn),
   }
 }
 
 /**
- * getLegendLabelMaxWidth - calculates the width of the longest label text in the legend
+ * getLabelMaxWidth - calculates the width of the longest label text in the legend
  * @param { array } keys - array of keys that will be in the legend
+ * @param { function } displayFn - function to apply on keys
  * @returns { number } - the width of the longest label text in the legend
  */
-const getLegendLabelMaxWidth = (keys) => keys.reduce((max, key) =>
-  Math.max(max, getTextSize(key)), 0)
+const getLabelMaxWidth = (keys, displayFn) => keys.reduce((max, key) =>
+  Math.max(max, getTextSize(displayFn(key))), 0)
 
 /**
  * getTextSize - calculates a rendered text width in pixels
@@ -348,7 +351,7 @@ export const getCommonProps = ({
   maxRowLegendItems,
   trimLegend
 }) => {
-  const maxLegendLabelWidth = getLegendLabelMaxWidth(keys)
+  const maxLegendLabelWidth = getLabelMaxWidth(keys, (x) => x)
   const legendItemCount = keys.length
 
   const {


### PR DESCRIPTION
- bar-chart/index.js, line-chart/index.js, scatter-chart/index.js: repleced lastYLabelWidth with maxYLabelWidth
- scatter-chart-data.js: changed y value to max 1
- utils/index.js: replaced lastYLabelWidth with maxYLabelWidth
- utils/index.js: replaced getLegendLabelMaxWidth with getLabelMaxWidth
- completed descriptions for setChartMargin and getLabelMaxWidth

Closes #88