### PR TITLE
[G2M] Tooltip - set notitle as string; add PropTypes.number to label prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A catch-all `{...nivoProps}` is passed along to each chart, though the values mi
   - 'monochromatic:' assign a different lightness for each data series; colorParam = hue value of blue, color, yellow, pink, purple, teal or gray
   - 'random': assign a data series a color at random; no coloParam required
 - **colorParam** - the param to configure the chosen colorType. Default is `70`
-- **colors** - array of color values to use for data, overrides colorType
+- **colors** - array of colour hex values or a function to retrieve colour hex values to use for data, overrides colorType
 - **axisBottomLegendLabel** - the label for the bottom axis
 - **axisBottomTrim** - whether or not to trim the bottom axis **label** values based on chart width. Default is `true`
 - **axisBottomLabelDisplayFn** - `labelValue => { ...return displayValue }` - function to customize the bottom axis tick labels. Default is `d => d`
@@ -53,6 +53,10 @@ typographyProps: {
     fontSize: 12,
     textColor: 'black'
   }
+```
+- **disableTooltipTitle** - prop to hide the title part in the tooltip:
+```javascript
+disableTooltipTitle: { false }
 ```
 
 #### Bar, Line and Scatter:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/chart-system",
   "private": false,
-  "version": "0.4.1",
+  "version": "0.4.2-alpha.2",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/src/components/bar-chart/index.js
+++ b/src/components/bar-chart/index.js
@@ -82,7 +82,7 @@ const BarChart = ({
     // ====[TODO] props for type (sum, max, min, avg)
     const aggregatedData = aggregateData({ data, keys: finalKeys, indexBy: finalIndexBy, groupByKey, valueKey, type: 'sum' })
     const finalData = processAxisOrder({ data: aggregatedData, axisBottomOrder, finalIndexBy })
-    const baseColors = colors.length ? colors : processColors(finalKeys.length, colorType, colorParam)
+    const baseColors = typeof colors === 'function' || !colors.length ? processColors(finalKeys.length, colorType, colorParam) : colors
     const baseDataToColorMap = finalKeys.reduce((agg, key, i) => ({ ...agg, [key]: baseColors[i] }), {})
     return {
       finalData,

--- a/src/components/line-chart/index.js
+++ b/src/components/line-chart/index.js
@@ -92,7 +92,7 @@ const ResponsiveLineChart = ({
     } = processSeriesDataKeys({ data, indexBy, xKey, yKeys, indexByValue })
     const unsortedData = convertDataToNivo({ data, indexBy: finalIndexBy, xKey: finalXKey, yKeys: finalYKeys, indexByValue })
     const nivoData = processAxisOrderNivo({ unsortedData, axisBottomOrder })
-    const baseColors = colors.length ? colors : processColors(nivoData.length, colorType, colorParam)
+    const baseColors = typeof colors === 'function' || !colors.length ? processColors(nivoData.length, colorType, colorParam) : colors
     // ====[TODO] flexible/repeat nature of colors could screw up { id: color } map
     // =========] would need to include repeat logic here?
     const baseDataToColorMap = nivoData.reduce((agg, o, i) => ({ ...agg, [o.id]: baseColors[i] }), {})

--- a/src/components/pie-chart/index.js
+++ b/src/components/pie-chart/index.js
@@ -80,7 +80,8 @@ const PieChart = ({
     const { finalIndexBy, finalDataKey } = processPieDataKeys({ data, indexBy, dataKey })
     const aggregatedData = aggregateData({ data, keys: [finalDataKey], indexBy: finalIndexBy, groupByKey, valueKey, type: 'sum' })
     const nivoData = convertPieDataToNivo({ data: aggregatedData, indexBy: finalIndexBy, dataKey: finalDataKey })
-    const baseColors = colors.length ? colors : processColors(data.length, colorType, colorParam)
+    const baseColors = typeof colors === 'function' || !colors.length ? processColors(data.length, colorType, colorParam) : colors
+
     return {
       nivoData,
       baseColors,

--- a/src/components/scatter-chart/index.js
+++ b/src/components/scatter-chart/index.js
@@ -79,7 +79,7 @@ const ScatterChart = ({
     } = processSeriesDataKeys({ data, indexBy, xKey, yKeys, indexByValue })
     const unsortedData = convertDataToNivo({ data, indexBy: finalIndexBy, xKey: finalXKey, yKeys: finalYKeys, indexByValue })
     const nivoData = processAxisOrderNivo({ unsortedData, axisBottomOrder })
-    const baseColors = colors.length ? colors : processColors(nivoData.length, colorType, colorParam)
+    const baseColors = typeof colors === 'function' || !colors.length ? processColors(nivoData.length, colorType, colorParam) : colors
     // ====[TODO] flexible/repeat nature of colors could screw up { id: color } map
     // =========] would need to include repeat logic here?
     const baseDataToColorMap = nivoData.reduce((agg, o, i) => ({ ...agg, [o.id]: baseColors[i] }), {})

--- a/src/components/tooltip/index.js
+++ b/src/components/tooltip/index.js
@@ -44,7 +44,10 @@ const TooltipData = styled('span')(({ typography = typographyDefaultProps.typogr
 `)
 
 const propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]).isRequired,
   color: PropTypes.string.isRequired,
   display: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string.isRequired,
@@ -77,7 +80,8 @@ const Tooltip = ({
         </TooltipLabel>
       </TooltipHeader>
     ) }
-    <TooltipBody notitle={ disableTooltipTitle }>
+    {/* set notitle to string to avoid Warning: Received `true` for a non-boolean attribute `notitle`. */}
+    <TooltipBody notitle={ disableTooltipTitle.toString()}>
       {display.map(({ label, value }) => (
         <TooltipData
           key={ label }

--- a/src/shared/constants/chart-props.js
+++ b/src/shared/constants/chart-props.js
@@ -22,7 +22,8 @@ export const chartPropTypes = {
   axisBottomLabelValues: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.number,
-    PropTypes.string, //for time
+    PropTypes.string,
+    PropTypes.object, //for time
   ]),
   axisLeftLegendLabel: PropTypes.string,
   axisLeftLabelDisplayFn: PropTypes.func,

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -460,6 +460,7 @@ export const getCommonProps = ({
     />
 
   const legend = {
+    id: 1,
     itemHeight: legend_height + BUFFER,
     symbolSize: SYMBOL_SIZE,
     symbolSpacing: SYMBOL_SPACING,

--- a/stories/responsive-chart-wrapper.js
+++ b/stories/responsive-chart-wrapper.js
@@ -17,7 +17,7 @@ const ChartDiv = styled('div')`
 `
 
 const layout = [
-  { i: 'a', x: 0, y: 0, w: 200, h: 6 }
+  { i: 'a', x: 0, y: 0, w: 200, h: 6 },
 ]
 
 const propTypes = { children: PropTypes.element }

--- a/stories/scatter.stories.js
+++ b/stories/scatter.stories.js
@@ -7,6 +7,9 @@ import ResponsiveChartWrapper from './responsive-chart-wrapper'
 
 
 const title = 'My Title'
+const palette = ['#1564ec', '#FF7641', '#FFA600', '#F936A9', '#B54DD5', '#FF4774']
+const colorsMap = {}
+scatterChartData.forEach((d, i) => colorsMap[d.Name] = palette[i])
 
 storiesOf('ScatterChart', module)
   .add('Widget Scatter Chart', () => (
@@ -16,6 +19,17 @@ storiesOf('ScatterChart', module)
         data={ scatterChartData }
         axisBottomLegendLabel={ 'axisBottomLegend' }
         axisLeftLegendLabel={ 'axisLeftLegend' }
+      />
+    </ResponsiveChartWrapper>
+  ))
+  .add('Widget Scatter Chart with colors as function', () => (
+    <ResponsiveChartWrapper>
+      <ScatterChart
+        title={ title }
+        data={ scatterChartData }
+        axisBottomLegendLabel={ 'axisBottomLegend' }
+        axisLeftLegendLabel={ 'axisLeftLegend' }
+        colors={(d) => colorsMap[d.serieId]}
       />
     </ResponsiveChartWrapper>
   ))

--- a/stories/title.stories.js
+++ b/stories/title.stories.js
@@ -37,7 +37,7 @@ storiesOf('Title', module)
           fontfamily: 'Orbitron',
           fontSize: '24px',
           fontWeight: 700,
-          textAlign: 'center'
+          textAlign: 'center',
         }}
         data={ scatterChartData }
         axisBottomLegendLabel={ 'axisBottomLegend' }

--- a/stories/typography.stories.js
+++ b/stories/typography.stories.js
@@ -16,7 +16,7 @@ storiesOf('Typography', module)
         typographyProps={{
           fontFamily: '"Orbitron", sans-serif',
           fontSize: 14,
-          textColor: 'red'
+          textColor: 'red',
         }}
         data={ scatterChartData }
         axisBottomLegendLabel={ 'axisBottomLegend' }


### PR DESCRIPTION
**Fixes:**

1. Set `notitle` prop in Tooltip as `string `and use it as such; added number prop type to `label`
2. Fix `baseColors` var in charts to work properly with `colors` as function
3. Add story for the above case
3. Add `id `key to `legend `var so we have an indexing key
4. Added `object `prop type to `axisBottomLabelValues` for when used with dates