### PR TITLE
[G2M] plotly - expect array of value keys in all charts

### DIFF
--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -52,7 +52,7 @@ const Bar = ({
 
 Bar.propTypes = {
   x: PropTypes.string.isRequired,
-  y: PropTypes.string.isRequired,
+  y: PropTypes.arrayOf(PropTypes.string).isRequired,
   stacked: PropTypes.bool,
   showTicks: PropTypes.bool,
   ...PlotlyPropTypes,

--- a/src/components/plotly/line/index.js
+++ b/src/components/plotly/line/index.js
@@ -53,7 +53,7 @@ const Line = ({
 
 Line.propTypes = {
   x: PropTypes.string.isRequired,
-  y: PropTypes.string.isRequired,
+  y: PropTypes.arrayOf(PropTypes.string).isRequired,
   spline: PropTypes.bool,
   showTicks: PropTypes.bool,
   ...PlotlyPropTypes,

--- a/src/components/plotly/pie/index.js
+++ b/src/components/plotly/pie/index.js
@@ -44,7 +44,7 @@ const Pie = ({
 
 Pie.propTypes = {
   label: PropTypes.string.isRequired,
-  values: PropTypes.string.isRequired,
+  values: PropTypes.arrayOf(PropTypes.string).isRequired,
   donut: PropTypes.bool,
   showPercentage: PropTypes.bool,
   showLegend: PropTypes.bool,

--- a/src/components/plotly/scatter/index.js
+++ b/src/components/plotly/scatter/index.js
@@ -51,7 +51,7 @@ const Scatter = ({
 
 Scatter.propTypes = {
   x: PropTypes.string.isRequired,
-  y: PropTypes.string.isRequired,
+  y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
   ...PlotlyPropTypes,
 }


### PR DESCRIPTION
Correcting an oversight made in #147 in which an incorrect PropType was applied to all plotly charts components.