### PR TITLE
[G2M] plotly - remove problematic responsive config flag

### DIFF
--- a/src/components/plotly/shared/responsive-plot.js
+++ b/src/components/plotly/shared/responsive-plot.js
@@ -34,7 +34,6 @@ const ResponsivePlot = ({ type, data, layout, subPlots, ...props }) => {
             :
             data.map(obj => ({ type, ...obj }))
         }
-        config={{ responsive: true }}
         layout={{
           width,
           autosize: true,


### PR DESCRIPTION
The Plotly `config.responsive` flag was causing a problem in certain styling contexts in `widget-studio`, and removing it does not seem to have any effects aside from solving this problem. Responsiveness is already handled by the `react-resize-detector` wrapper.