### PR TITLE
[G2M] plotly - re-add responsive config flag

### DIFF
--- a/src/components/plotly/shared/responsive-plot.js
+++ b/src/components/plotly/shared/responsive-plot.js
@@ -44,6 +44,7 @@ const ResponsivePlot = ({ type, data, layout, subPlots, ...props }) => {
             :
             data.map(obj => ({ type, ...obj }))
         }
+        config={{ responsive: true }}
         layout={{
           width,
           autosize: true,


### PR DESCRIPTION
reverting change made in #153.... 🤦 Everything seems to behave correctly in the `widget-studio` context with this change, in all widget view modes.

[Discussion here](https://eqworks.slack.com/archives/GV827LS0M/p1634821767000300)