### PR TITLE
[G2M] Plotly/axis titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/chart-system",
   "private": false,
-  "version": "0.6.3-alpha.10",
+  "version": "0.6.3-alpha.11",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -10,6 +10,9 @@ const Bar = ({
   data,
   stacked,
   showTicks,
+  showAxisTitles,
+  x,
+  y,
   ...props
 }) => (
   <CustomPlot
@@ -18,6 +21,8 @@ const Bar = ({
       useTransformedData({
         type: 'bar',
         data,
+        x,
+        y,
         ...props,
       })
     }
@@ -26,10 +31,23 @@ const Bar = ({
       xaxis: {
         showticklabels: showTicks,
         automargin: true,
+        type: 'category',
+        ...(showAxisTitles && {
+          title: {
+            text: x,
+            standoff: 20,
+          },
+        }),
       },
       yaxis: {
         showticklabels: showTicks,
         automargin: true,
+        ...(showAxisTitles && y?.length === 1 && {
+          title: {
+            text: y[0],
+            standoff: 30,
+          },
+        }),
       },
     }}
     {...props}
@@ -41,12 +59,14 @@ Bar.propTypes = {
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   stacked: PropTypes.bool,
   showTicks: PropTypes.bool,
+  showAxisTitles: PropTypes.bool,
   ...plotlyPropTypes,
 }
 
 Bar.defaultProps = {
   stacked: false,
   showTicks: true,
+  showAxisTitles: true,
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/line/index.js
+++ b/src/components/plotly/line/index.js
@@ -10,6 +10,9 @@ const Line = ({
   data,
   spline,
   showTicks,
+  showAxisTitles,
+  x,
+  y,
   ...props
 }) => (
   <CustomPlot
@@ -18,6 +21,8 @@ const Line = ({
       useTransformedData({
         type: 'line',
         data,
+        x,
+        y,
         extra: {
           line: {
             shape: spline ? 'spline' : 'linear',
@@ -30,10 +35,22 @@ const Line = ({
       xaxis: {
         showticklabels: showTicks,
         automargin: true,
+        ...(showAxisTitles && {
+          title: {
+            text: x,
+            standoff: 20,
+          },
+        }),
       },
       yaxis: {
         showticklabels: showTicks,
         automargin: true,
+        ...(showAxisTitles && y?.length === 1 && {
+          title: {
+            text: y[0],
+            standoff: 30,
+          },
+        }),
       },
     }}
     {...props}
@@ -45,12 +62,14 @@ Line.propTypes = {
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   spline: PropTypes.bool,
   showTicks: PropTypes.bool,
+  showAxisTitles: PropTypes.bool,
   ...plotlyPropTypes,
 }
 
 Line.defaultProps = {
   spline: false,
   showTicks: true,
+  showAxisTitles: true,
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/scatter/index.js
+++ b/src/components/plotly/scatter/index.js
@@ -10,6 +10,9 @@ const Scatter = ({
   data,
   showTicks,
   showLines,
+  showAxisTitles,
+  x,
+  y,
   ...props
 }) => (
   <CustomPlot
@@ -18,6 +21,8 @@ const Scatter = ({
       useTransformedData({
         type: 'scatter',
         data,
+        x,
+        y,
         extra: {
           mode: showLines ? 'lines+markers' : 'markers',
         },
@@ -28,10 +33,22 @@ const Scatter = ({
       xaxis: {
         showticklabels: showTicks,
         automargin: true,
+        ...(showAxisTitles && {
+          title: {
+            text: x,
+            standoff: 20,
+          },
+        }),
       },
       yaxis: {
         showticklabels: showTicks,
         automargin: true,
+        ...(showAxisTitles && y?.length === 1 && {
+          title: {
+            text: y[0],
+            standoff: 30,
+          },
+        }),
       },
       ...!showTicks && {
         margin: {
@@ -50,11 +67,13 @@ Scatter.propTypes = {
   x: PropTypes.string.isRequired,
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
+  showAxisTitles: PropTypes.bool,
   ...plotlyPropTypes,
 }
 
 Scatter.defaultProps = {
   showTicks: true,
+  showAxisTitles: true,
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/shared/custom-plot.js
+++ b/src/components/plotly/shared/custom-plot.js
@@ -13,7 +13,7 @@ import styles from './styles'
 const DEFAULT_SIZE = 0.8 // [0, 1]
 const MIN_SIZE = 0.5 // [0, 1]
 
-const SUBPLOT_COLUMNS = 2
+const DEFAULT_SUBPLOT_COLUMNS = 2
 
 const CustomPlot = ({
   type,
@@ -29,7 +29,11 @@ const CustomPlot = ({
   showLegend,
 }) => {
   // determine subplot requirements
-  const doSubPlots = useMemo(() => data.length > 1 && subPlots, [data.length, subPlots])
+  const subPlotColumns = useMemo(() => Math.min(DEFAULT_SUBPLOT_COLUMNS, data.length), [data.length])
+  const subPlotRows = useMemo(() => Math.ceil(data.length / subPlotColumns), [data.length, subPlotColumns])
+  const doSubPlots = useMemo(() => type === 'pie' || (data.length > 1 && subPlots), [data.length, subPlots, type])
+
+  // compute sizing stuff
   const finalVizSize = useMemo(() => (
     doSubPlots
       ? MIN_SIZE + (size * (1 - MIN_SIZE))
@@ -37,10 +41,9 @@ const CustomPlot = ({
   ), [doSubPlots, size])
   const legendMargin = useMemo(() => (
     doSubPlots
-      ? (1 - finalVizSize) / SUBPLOT_COLUMNS / 2
+      ? (1 - finalVizSize) / subPlotColumns / 2
       : (1 - finalVizSize) / 2
-  ), [doSubPlots, finalVizSize])
-  const subPlotRows = useMemo(() => Math.ceil(data.length / SUBPLOT_COLUMNS), [data.length])
+  ), [doSubPlots, subPlotColumns, finalVizSize])
 
   // memoize layout object
   const finalLayout = useMemo(() => merge(layout, PLOTLY_BASE_LAYOUT), [layout])
@@ -158,11 +161,11 @@ const CustomPlot = ({
             ? <>
               <styles.GenericContainer>
                 {renderTitle}
-                <styles.SubPlotGrid columns={SUBPLOT_COLUMNS} rows={subPlotRows}>
+                <styles.SubPlotGrid columns={subPlotColumns} rows={subPlotRows}>
                   {coloredData.map((d, i) => renderPlot([d], d.name, i))}
                 </styles.SubPlotGrid >
                 <styles.HiddenContainer>
-                  <styles.SubPlotGrid columns={SUBPLOT_COLUMNS} rows={subPlotRows}>
+                  <styles.SubPlotGrid columns={subPlotColumns} rows={subPlotRows}>
                     {renderDummy}
                   </styles.SubPlotGrid >
                 </styles.HiddenContainer>


### PR DESCRIPTION
## dependency for EQWorks/widget-studio#97

---

introduce `showAxisTitles` prop... self-explanatory. Valid for bar, line, and scatter components.

Currently, the titles are rendered on each subplot if `showAxisTitles === true`. Perhaps this can be reconsidered later.

The y-axis title is rendered **only** if there is one value to be plotted. Otherwise, we rely on the legend to provide the labelling. 

For example, axis titles are shown here:

![image](https://user-images.githubusercontent.com/53827672/155150718-4d684df9-9cc5-4f95-b5e8-a02a8a807974.png)


but not here:

![image](https://user-images.githubusercontent.com/53827672/155150872-f8027746-4227-4aec-a5e6-2333149b205e.png)

---

in the next iteration, would like to show a different y-axis title for each subplot.
