### PR TITLE
[WIP] Deps/update lumen labs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/chart-system",
   "private": false,
-  "version": "0.6.3-alpha.11",
+  "version": "0.6.3-alpha.12",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -33,16 +33,13 @@
     "d3-scale": "^3.2.1",
     "d3-shape": "^1.3.7",
     "d3-time": "^2.0.0",
-    "eslint-plugin-react-hooks": "^4.2.1-alpha-e6be2d531",
     "goober": "^2.0.5",
     "iwanthue": "^1.5.1",
     "lodash.merge": "^4.6.2",
     "lodash.omit": "^4.5.0",
     "plotly.js-basic-dist-min": "^2.8.3",
     "prop-types": "^15.7.2",
-    "react-resizable": "^1.10.1",
-    "react-resize-detector": "^7.0.0",
-    "storybook": "^6.1.20"
+    "react-resize-detector": "^7.0.0"
   },
   "peerDependencies": {
     "@eqworks/lumen-labs": "^0.1.0-alpha.37",
@@ -117,16 +114,19 @@
     "@storybook/addons": "^6.0.12",
     "@storybook/react": "^6.0.12",
     "@storybook/storybook-deployer": "^2.8.6",
+    "storybook": "^6.1.20",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.1.0",
     "babel-loader": "^8.1.0",
     "eslint": "^6.8.0",
     "eslint-plugin-react": "^7.18.3",
+    "eslint-plugin-react-hooks": "^4.2.1-alpha-e6be2d531",
     "eslint-watch": "^6.0.1",
     "jest-cli": "^25.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-grid-layout": "^0.18.3",
+    "react-resizable": "^1.10.1",
     "size-limit": "^4.5.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "url": "https://github.com/EQWorks/chart-system.git"
   },
   "dependencies": {
-    "@eqworks/lumen-labs": "^0.1.0-alpha.25",
     "@nivo/bar": "^0.62.0",
     "@nivo/core": "^0.62.0",
     "@nivo/legends": "^0.62.0",
@@ -46,6 +45,7 @@
     "storybook": "^6.1.20"
   },
   "peerDependencies": {
+    "@eqworks/lumen-labs": "^0.1.0-alpha.37",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },
@@ -107,6 +107,7 @@
     "@babel/plugin-transform-runtime": "^7.11.0",
     "@babel/preset-env": "^7.10.3",
     "@babel/preset-react": "^7.9.4",
+    "@eqworks/lumen-labs": "^0.1.0-alpha.40",
     "@size-limit/preset-small-lib": "^4.5.6",
     "@storybook/addon-actions": "^6.0.12",
     "@storybook/addon-docs": "^6.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,10 +1252,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@eqworks/lumen-labs@^0.1.0-alpha.25":
-  version "0.1.0-alpha.25"
-  resolved "https://npm.pkg.github.com/download/@eqworks/lumen-labs/0.1.0-alpha.25/5b123e17102ba66b261cce6a694a3626ee3dc830d80a02aeeeb1fd4d3584be4a#3aa6ac009b49ab10e563f1094f462a4ed13dd13a"
-  integrity sha512-5A3LGsi/4J/l0RFAMi5yS8cWYIqOAnZujnL99w+gEwtagjK/HrEcQGJwslOdAu5kyBzKqXk3SrsNCRnHYytBWw==
+"@eqworks/lumen-labs@^0.1.0-alpha.40":
+  version "0.1.0-alpha.40"
+  resolved "https://npm.pkg.github.com/download/@eqworks/lumen-labs/0.1.0-alpha.40/62c101c8a5d932dc3ece9bc38c4cb09a6be13b9ea1cc8e92457de0df6094f33f#43e89f9d6b145cb0a7142dd1cbea876f94842fc2"
+  integrity sha512-vmC3twy/aUgEucyPxXFB+678ffXVRK4oVQoO0qj6TzxeEpfmpGZ7e54yKSQmNxZAkq5kd53KUQEpkkM9Qg2mJA==
   dependencies:
     "@headlessui/react" "^1.4.0"
     clsx "^1.1.1"
@@ -1264,6 +1264,7 @@
     react-resize-detector "^6.7.6"
     react-virtualized-auto-sizer "^1.0.5"
     react-window "^1.8.6"
+    use-debounce "^7.0.1"
 
 "@headlessui/react@^1.4.0":
   version "1.4.3"
@@ -13262,6 +13263,11 @@ use-composed-ref@^1.0.0:
   integrity sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==
   dependencies:
     ts-essentials "^2.0.3"
+
+use-debounce@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-7.0.1.tgz#380e6191cc13ad29f8e2149a12b5c37cc2891190"
+  integrity sha512-fOrzIw2wstbAJuv8PC9Vg4XgwyTLEOdq4y/Z3IhVl8DAE4svRcgyEUvrEXu+BMNgMoc3YND6qLT61kkgEKXh7Q==
 
 use-isomorphic-layout-effect@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
## :construction: WIP

updated `lumen-labs` to most recent alpha, and moved it to a peer/dev instead of a regular dependency. Also moved some other regular dependencies that were incorrectly assigned as regular deps instead of peer/dev. 