### PR TITLE
[G2M] Pie inline label, and generic/hack interface for arbitrary hole/textinfo configs

### DIFF
--- a/src/components/plotly/pie/index.js
+++ b/src/components/plotly/pie/index.js
@@ -17,7 +17,8 @@ const Pie = ({
   data,
   showPercentage,
   showLabelName,
-  extra,
+  textinfo,
+  hole,
   ...props
 }) => (
   <CustomPlot
@@ -26,9 +27,8 @@ const Pie = ({
       type: 'pie',
       data,
       extra: {
-        textinfo: getTextInfo({ showPercentage, showLabelName }),
-        hole: donut ? 0.4 : 0,
-        ...extra, // generic/hack interface to override textinfo, hole, and possibly others
+        textinfo: textinfo ?? getTextInfo({ showPercentage, showLabelName }),
+        hole: hole ?? (donut ? 0.4 : 0),
       },
       ...props,
     })}
@@ -42,7 +42,8 @@ Pie.propTypes = {
   donut: PropTypes.bool,
   showPercentage: PropTypes.bool,
   showLabelName: PropTypes.bool,
-  extra: PropTypes.object,
+  textinfo: PropTypes.string,
+  hole: PropTypes.number,
   ...plotlyPropTypes,
 }
 
@@ -50,7 +51,8 @@ Pie.defaultProps = {
   donut: false,
   showPercentage: true,
   showLabelName: false,
-  extra: {},
+  textinfo: null,
+  hole: null,
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/pie/index.js
+++ b/src/components/plotly/pie/index.js
@@ -17,7 +17,7 @@ const Pie = ({
       type: 'pie',
       data,
       extra: {
-        textinfo: showPercentage ? 'values' : 'none',
+        textinfo: showPercentage ? 'percent' : 'none',
         hole: donut ? 0.4 : 0,
       },
       ...props,

--- a/src/components/plotly/pie/index.js
+++ b/src/components/plotly/pie/index.js
@@ -5,10 +5,18 @@ import { plotlyDefaultProps, plotlyPropTypes } from '../shared/constants'
 import CustomPlot from '../shared/custom-plot'
 import useTransformedData from '../shared/use-transformed-data'
 
+const getTextInfo = ({ showPercentage, showLabelName }) => {
+  if (showPercentage) {
+    return showLabelName ? 'label+percent' : 'percent'
+  }
+  return 'none'
+}
+
 const Pie = ({
   donut,
   data,
   showPercentage,
+  showLabelName,
   ...props
 }) => (
   <CustomPlot
@@ -17,7 +25,7 @@ const Pie = ({
       type: 'pie',
       data,
       extra: {
-        textinfo: showPercentage ? 'percent' : 'none',
+        textinfo: getTextInfo({ showPercentage, showLabelName }),
         hole: donut ? 0.4 : 0,
       },
       ...props,
@@ -31,12 +39,14 @@ Pie.propTypes = {
   values: PropTypes.arrayOf(PropTypes.string).isRequired,
   donut: PropTypes.bool,
   showPercentage: PropTypes.bool,
+  showLabelName: PropTypes.bool,
   ...plotlyPropTypes,
 }
 
 Pie.defaultProps = {
   donut: false,
   showPercentage: true,
+  showLabelName: false,
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/pie/index.js
+++ b/src/components/plotly/pie/index.js
@@ -17,6 +17,7 @@ const Pie = ({
   data,
   showPercentage,
   showLabelName,
+  extra,
   ...props
 }) => (
   <CustomPlot
@@ -27,6 +28,7 @@ const Pie = ({
       extra: {
         textinfo: getTextInfo({ showPercentage, showLabelName }),
         hole: donut ? 0.4 : 0,
+        ...extra, // generic/hack interface to override textinfo, hole, and possibly others
       },
       ...props,
     })}
@@ -40,6 +42,7 @@ Pie.propTypes = {
   donut: PropTypes.bool,
   showPercentage: PropTypes.bool,
   showLabelName: PropTypes.bool,
+  extra: PropTypes.object,
   ...plotlyPropTypes,
 }
 
@@ -47,6 +50,7 @@ Pie.defaultProps = {
   donut: false,
   showPercentage: true,
   showLabelName: false,
+  extra: {},
   ...plotlyDefaultProps,
 }
 

--- a/stories/plotly/plotly-pie.stories.js
+++ b/stories/plotly/plotly-pie.stories.js
@@ -23,12 +23,10 @@ export const Default = Template.bind({})
 export const WithLabelName = Template.bind({})
 WithLabelName.args = { showLabelName: true }
 
-export const PlotlyExtraOverride = Template.bind({})
-PlotlyExtraOverride.args = {
-  extra: {
-    textinfo: 'label+value+percent',
-    hole: '0.9',
-  },
+export const PlotlyOverride = Template.bind({})
+PlotlyOverride.args = {
+  textinfo: 'label+value+percent',
+  hole: 0.9,
 }
 
 export const Donut = Template.bind({})

--- a/stories/plotly/plotly-pie.stories.js
+++ b/stories/plotly/plotly-pie.stories.js
@@ -20,6 +20,9 @@ const Template = (args) =>
 
 export const Default = Template.bind({})
 
+export const WithLabelName = Template.bind({})
+WithLabelName.args = { showLabelName: true }
+
 export const Donut = Template.bind({})
 Donut.args = { donut: true }
 

--- a/stories/plotly/plotly-pie.stories.js
+++ b/stories/plotly/plotly-pie.stories.js
@@ -23,6 +23,14 @@ export const Default = Template.bind({})
 export const WithLabelName = Template.bind({})
 WithLabelName.args = { showLabelName: true }
 
+export const PlotlyExtraOverride = Template.bind({})
+PlotlyExtraOverride.args = {
+  extra: {
+    textinfo: 'label+value+percent',
+    hole: '0.9',
+  },
+}
+
 export const Donut = Template.bind({})
 Donut.args = { donut: true }
 


### PR DESCRIPTION
default behavior intact as before (however, the initial implementation of `textinfo` was incorrect. it should have been either `percent` or `value`, instead of `values`, "fixed" in https://github.com/EQWorks/chart-system/commit/9a3f9116029a35d0e68817334d20c64b58d58b7a)

- add `showLabelName` (`bool`) to show label name in plotly/pie's `textinfo` (`"label+<type>"`)
  ![showLabelName](https://user-images.githubusercontent.com/2837532/163481257-bd407297-f1fe-45d8-b0ee-19ca22dd3cd1.png)
- explicitly surface `hole`, `textinfo` configs for plotly/pie (example below with `{ hole: '0.9', textinfo: 'label+percent+value' }`:
  ![extra](https://user-images.githubusercontent.com/2837532/163481419-dc81f025-0152-47b3-b5c4-309d6fd64d80.png)