### PR TITLE
[G2M] plotly - pie & bar horizontal output value access fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/chart-system",
   "private": false,
-  "version": "0.7.3",
+  "version": "0.7.4-alpha.1",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/chart-system",
   "private": false,
-  "version": "0.7.4-alpha.1",
+  "version": "0.7.4",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/src/components/plotly/pie/index.js
+++ b/src/components/plotly/pie/index.js
@@ -19,6 +19,7 @@ const Pie = ({
   showLabelName,
   textinfo,
   hole,
+  formatData,
   ...props
 }) => (
   <CustomPlot
@@ -30,6 +31,7 @@ const Pie = ({
         textinfo: textinfo ?? getTextInfo({ showPercentage, showLabelName }),
         hole: hole ?? (donut ? 0.4 : 0),
       },
+      formatData,
       ...props,
     })}
     {...props}
@@ -44,6 +46,7 @@ Pie.propTypes = {
   showLabelName: PropTypes.bool,
   textinfo: PropTypes.string,
   hole: PropTypes.number,
+  formatData: PropTypes.objectOf(PropTypes.func),
   ...plotlyPropTypes,
 }
 
@@ -53,6 +56,7 @@ Pie.defaultProps = {
   showLabelName: false,
   textinfo: null,
   hole: null,
+  formatData: {},
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/shared/use-transformed-data.js
+++ b/src/components/plotly/shared/use-transformed-data.js
@@ -32,7 +32,7 @@ const getObjectByType = ( data, type, domain, range, args, key, format, grouped 
     if (type === 'bar') {
       typeConfig = {
         [domain.output]: args?.orientation === 'h' ? data.map(d => d[key]) : data.map(d => d[args[domain.input]]), 
-        [range.output]: args?.orientation === 'h' ? data.map(d => d[args[range.input]]) : data.map(d => d[key]), 
+        [range.output]: args?.orientation === 'h' ? data.map(d => d[args[domain.input]]) : data.map(d => d[key]), 
         orientation: args.orientation,
         text: data.map(d => getText(d[key], format && format)),
         textposition: args?.orientation === 'h' ? args.textPosition : 'none',


### PR DESCRIPTION
fixes #183 
- Fixed bar horizontal output value access 
- Fixed pie output value access
- Added FormatData option for pie