### PR TITLE
[G2M] Horizontal Bar text value fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/chart-system",
   "private": false,
-  "version": "0.7.4",
+  "version": "0.7.5",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -28,51 +28,65 @@ const Bar = ({
     }
   }
 
+  const _data = useTransformedData({
+    type: 'bar',
+    data,
+    x,
+    y,
+    orientation,
+    textPosition,
+    formatData,
+    ...props,
+  })
+
+  const getMaxRange = (data) => {
+    const xAxisValues = data.map(v => Math.max(...v.x))
+    const roundUpValue = Math.ceil(Math.max(...xAxisValues))
+    const arrayOfZero = [...Array(roundUpValue.toString().length - 1).fill('0')]
+
+    let valueUnit = '1'
+    arrayOfZero.forEach(v => valueUnit = valueUnit + v)
+    
+    const maxRange = (Math.ceil(Math.ceil(Math.max(...xAxisValues)) / valueUnit) * valueUnit) * 1.1
+
+    return Number(maxRange.toFixed(0))
+  }
+
   return (
-    <CustomPlot
-      type='bar'
-      data={
-        useTransformedData({
-          type: 'bar',
-          data,
-          x,
-          y,
-          orientation,
-          textPosition,
-          formatData,
-          ...props,
-        })
-      }
-      layout={{
-        barmode: stacked ? 'stack' : 'group',
-        xaxis: {
-          showticklabels: showTicks,
-          ticksuffix: tickSuffix[0] || orientation === 'h' && showPercentage && '%',
-          tickprefix: tickPrefix[0],
-          automargin: true,
-          ...(showAxisTitles && {
-            title: getAxisTitle('v'),
-          }),
-        },
-        yaxis: {
-          showticklabels: showTicks,
-          ticksuffix: tickSuffix[1] || orientation === 'v' && showPercentage && '%',
-          tickprefix: tickPrefix[1],
-          automargin: true,
-          ...(showAxisTitles && {
-            title: getAxisTitle('h'),
-          }),
-        },
-        margin: {
-          l: 50,
-          r: 50,
-          b: 100,
-          t: 100,
-          pad: 4,
-        },
-      }}
-      {...props}
-    />
+      <CustomPlot
+        type='bar'
+        data={_data}
+        layout={{
+          barmode: stacked ? 'stack' : 'group',
+          xaxis: {
+            range: orientation === 'v' && stacked ? [] : [0, getMaxRange(_data)],
+            showticklabels: showTicks,
+            ticksuffix: tickSuffix[0] || orientation === 'h' && showPercentage && '%',
+            tickprefix: tickPrefix[0],
+            automargin: true,
+            ...(showAxisTitles && {
+              title: getAxisTitle('v'),
+            }),
+          },
+          yaxis: {
+            showticklabels: showTicks,
+            ticksuffix: tickSuffix[1] || orientation === 'v' && showPercentage && '%',
+            tickprefix: tickPrefix[1],
+            automargin: true,
+            ...(showAxisTitles && {
+              title: getAxisTitle('h'),
+            }),
+          },
+          margin: {
+            l: 50,
+            r: 50,
+            b: 100,
+            t: 100,
+            pad: 4,
+          },
+        }}
+        {...props}
+      />
   )
 }
 

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -41,15 +41,15 @@ const Bar = ({
 
   const getMaxRange = (data) => {
     const xAxisValues = data.map(v => Math.max(...v.x))
-    const roundUpValue = Math.ceil(Math.max(...xAxisValues))
+    const roundUpValue = Math.ceil(stacked ? xAxisValues.reduce((a, b) => a + b, 0) : Math.max(...xAxisValues))
     const arrayOfZero = [...Array(roundUpValue.toString().length - 1).fill('0')]
 
     let valueUnit = '1'
     arrayOfZero.forEach(v => valueUnit = valueUnit + v)
     
-    const maxRange = (Math.ceil(Math.ceil(Math.max(...xAxisValues)) / valueUnit) * valueUnit) * 1.1
+    const maxRange = (Math.ceil(roundUpValue / valueUnit) * valueUnit) * 1.1
 
-    return Number(maxRange.toFixed(0))
+    return Number((stacked ? (roundUpValue * 1.15) : maxRange).toFixed(0))
   }
 
   return (
@@ -59,7 +59,7 @@ const Bar = ({
       layout={{
         barmode: stacked ? 'stack' : 'group',
         xaxis: {
-          range: orientation === 'h' && stacked ? [] : [0, getMaxRange(_data)],
+          range: orientation === 'h' && [0, getMaxRange(_data)],
           showticklabels: showTicks,
           ticksuffix: tickSuffix[0] || orientation === 'h' && showPercentage && '%',
           tickprefix: tickPrefix[0],

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -53,40 +53,40 @@ const Bar = ({
   }
 
   return (
-      <CustomPlot
-        type='bar'
-        data={_data}
-        layout={{
-          barmode: stacked ? 'stack' : 'group',
-          xaxis: {
-            range: orientation === 'v' && stacked ? [] : [0, getMaxRange(_data)],
-            showticklabels: showTicks,
-            ticksuffix: tickSuffix[0] || orientation === 'h' && showPercentage && '%',
-            tickprefix: tickPrefix[0],
-            automargin: true,
-            ...(showAxisTitles && {
-              title: getAxisTitle('v'),
-            }),
-          },
-          yaxis: {
-            showticklabels: showTicks,
-            ticksuffix: tickSuffix[1] || orientation === 'v' && showPercentage && '%',
-            tickprefix: tickPrefix[1],
-            automargin: true,
-            ...(showAxisTitles && {
-              title: getAxisTitle('h'),
-            }),
-          },
-          margin: {
-            l: 50,
-            r: 50,
-            b: 100,
-            t: 100,
-            pad: 4,
-          },
-        }}
-        {...props}
-      />
+    <CustomPlot
+      type='bar'
+      data={_data}
+      layout={{
+        barmode: stacked ? 'stack' : 'group',
+        xaxis: {
+          range: orientation === 'h' && stacked ? [] : [0, getMaxRange(_data)],
+          showticklabels: showTicks,
+          ticksuffix: tickSuffix[0] || orientation === 'h' && showPercentage && '%',
+          tickprefix: tickPrefix[0],
+          automargin: true,
+          ...(showAxisTitles && {
+            title: getAxisTitle('v'),
+          }),
+        },
+        yaxis: {
+          showticklabels: showTicks,
+          ticksuffix: tickSuffix[1] || orientation === 'v' && showPercentage && '%',
+          tickprefix: tickPrefix[1],
+          automargin: true,
+          ...(showAxisTitles && {
+            title: getAxisTitle('h'),
+          }),
+        },
+        margin: {
+          l: 50,
+          r: 50,
+          b: 100,
+          t: 100,
+          pad: 4,
+        },
+      }}
+      {...props}
+    />
   )
 }
 

--- a/src/components/plotly/pyramid-bar/index.js
+++ b/src/components/plotly/pyramid-bar/index.js
@@ -69,7 +69,7 @@ const PyramidBar = ({
           showticklabels: showTicks,
           automargin: true,
           type: 'linear', 
-          range: [-Math.abs(maxVal * 1.2), maxVal * 1.2], 
+          range: [-Math.abs(maxVal * 1.5), maxVal * 1.5], 
           ticktext: getTickText(), 
           tickvals: [...x.map(val => -Math.abs(val)), 0, ...xValReverse],
           ticksuffix: tickSuffix[0],


### PR DESCRIPTION
fixes #181 

- Fixed plotly horizontal bar text value cut-off

![Screen Shot 2022-09-20 at 2 08 36 PM](https://user-images.githubusercontent.com/46459367/191332316-1ab7bbf1-e296-450b-860c-daa03c1fec25.png)

when it gets too small it will still cut off but I think that's a very extreme case
![Screen Shot 2022-09-20 at 2 27 40 PM](https://user-images.githubusercontent.com/46459367/191335913-964443d3-8430-492e-a531-32dc4b5ac8df.png)