### PR TITLE
[G2M] Plotly - adjust legend styling to Cox design

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/chart-system",
   "private": false,
-  "version": "0.7.7",
+  "version": "0.7.8",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/src/components/plotly/shared/legend.js
+++ b/src/components/plotly/shared/legend.js
@@ -14,8 +14,8 @@ const Legend = ({
     {
       keys.map((k, i) => (
         <Styles.LegendItem key={i}>
-          <Styles.LegendColorBox color={colors[i]} rightAligned={x > 0.5} />
-          <Styles.LegendString rightAligned={x > 0.5}>
+          <Styles.LegendColorBox color={colors[i]} />
+          <Styles.LegendString>
             {k}
           </Styles.LegendString>
         </Styles.LegendItem>

--- a/src/components/plotly/shared/styles/index.js
+++ b/src/components/plotly/shared/styles/index.js
@@ -6,7 +6,7 @@ import legendStyles from './legend'
 import utilStyles from './util'
 
 setup(createElement, undefined, undefined, shouldForwardProp((prop) => {
-  return prop !== 'showLegend' && prop !== 'legendPosition' && prop !== 'rightAligned'
+  return !['showLegend', 'legendPosition'].includes(prop)
 }))
 
 export default {
@@ -26,6 +26,7 @@ export default {
         gridStyle = { gridTemplateColumns: 'fit-content(20%) 1fr' }
       }
     }
+
     return {
       width: '100%',
       height: '100%',
@@ -34,6 +35,7 @@ export default {
       ...gridStyle,
     }
   }),
+
   GenericContainer: styled('div')({
     display: 'flex',
     flexDirection: 'column',
@@ -43,6 +45,7 @@ export default {
     height: '100%',
     transition: 'width 0.3s, height 0.3s',
   }),
+
   ContentContainer: styled('div')({
     fontFamily: 'Open Sans,sans-serif',
     position: 'relative',

--- a/src/components/plotly/shared/styles/legend.js
+++ b/src/components/plotly/shared/styles/legend.js
@@ -25,7 +25,6 @@ export default {
       fontWeight: 600,
       fontSize: '0.8rem',
       position: 'relative',
-      textTransform: 'capitalize',
       ...positionStyle,
     }
   }),
@@ -36,19 +35,16 @@ export default {
     alignItems: 'center',
   }),
 
-  LegendColorBox: styled('div')(({ rightAligned, color }) => ({
-    order: + !rightAligned,
+  LegendColorBox: styled('div')(({ color }) => ({
     background: color,
     borderRadius: '0.2rem',
     width: '1rem',
     height: '1rem',
     margin: '0 0.5rem',
-  }),
-  ),
-  LegendString: styled('div')(({ rightAligned }) => ({
-    order: + rightAligned,
-    textAlign: rightAligned ? 'right' : 'left',
+  })),
+
+  LegendString: styled('div')({
+    textAlign: 'left',
     flex: 1,
   }),
-  ),
 }


### PR DESCRIPTION
**Changes:**

#### Plotly - Legend
- changed position of label in legend & styling to fit with Figma design

**Figma design:**
<img width="596" alt="Screen Shot 2022-10-05 at 11 48 28 AM" src="https://user-images.githubusercontent.com/41120953/194104805-409ee1c6-e6db-4c44-bcd7-7c0e68902336.png">

**Without fix in Cox app:**
<img width="512" alt="Screen Shot 2022-10-05 at 11 46 25 AM" src="https://user-images.githubusercontent.com/41120953/194104902-76d92012-fdba-4f86-bd46-040c3459ecab.png">

**With fix in Widget Studio:**
<img width="959" alt="Screen Shot 2022-10-05 at 11 45 52 AM" src="https://user-images.githubusercontent.com/41120953/194105060-7bac3987-faaa-4ae4-b073-ffe41475855a.png">
