### PR TITLE
[G2M] Plotly charts - add showAxisTitles prop, change axisTitles from array to obj

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/chart-system",
   "private": false,
-  "version": "0.7.9",
+  "version": "0.8.0-alpha.2",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/chart-system",
   "private": false,
-  "version": "0.8.0-alpha.2",
+  "version": "0.8.0",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/src/components/plotly/bar-line/index.js
+++ b/src/components/plotly/bar-line/index.js
@@ -34,12 +34,12 @@ const BarLine = ({
     })[0],
   }
 
-  const scatter_data = {
-    type: 'scatter',
+  const line_data = {
+    type: 'line',
     yaxis: 'y2',
     connectgaps: true,
     ...useTransformedData({
-      type: 'scatter',
+      type: 'line',
       data,
       x,
       y: [y[1] ? y[1] : y[0]],
@@ -59,7 +59,7 @@ const BarLine = ({
       <CustomPlot
         type='barline'
         data={y[1] ? [
-          scatter_data,
+          line_data,
           bar_data,
         ] : [bar_data]}
         layout={{
@@ -67,6 +67,7 @@ const BarLine = ({
             showticklabels: showTicks,
             tickmode: 'linear',
             tickformat: '%b %d',
+            automargin: true,
             ...(showAxisTitles.x && {
               title: {
                 standoff: 20,

--- a/src/components/plotly/bar-line/index.js
+++ b/src/components/plotly/bar-line/index.js
@@ -10,6 +10,7 @@ const BarLine = ({
   data,
   showTicks,
   showAxisTitles,
+  axisTitles,
   x,
   y,
   showCurrency,
@@ -66,12 +67,18 @@ const BarLine = ({
             showticklabels: showTicks,
             tickmode: 'linear',
             tickformat: '%b %d',
-          },
-          yaxis: {
-            ...(showAxisTitles && y[0] && { 
+            ...(showAxisTitles.x && {
               title: {
                 standoff: 20,
-                text: y[0],
+                text: axisTitles.x || x,
+              },
+            }),
+          },
+          yaxis: {
+            ...(showAxisTitles.y && y[0] && {
+              title: {
+                standoff: 20,
+                text: axisTitles.y || y[0],
               },
             }),
             showticklabels: showTicks,
@@ -80,10 +87,10 @@ const BarLine = ({
             overlaying: 'y2',
           },
           yaxis2: {
-            ...(showAxisTitles && y[1] && { 
+            ...(showAxisTitles.y2 && y[1] && {
               title: {
                 standoff: 20,
-                text: y[1],
+                text: axisTitles.y2 || y[1],
               },
             }),
             showticklabels: showTicks,
@@ -100,7 +107,8 @@ BarLine.propTypes = {
   x: PropTypes.string.isRequired,
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.bool,
+  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
+  axisTitles: PropTypes.objectOf(PropTypes.string),
   showCurrency: PropTypes.bool,
   formatData: PropTypes.objectOf(PropTypes.func),
   hoverInfo: PropTypes.string,
@@ -113,7 +121,16 @@ BarLine.propTypes = {
 
 BarLine.defaultProps = {
   showTicks: true,
-  showAxisTitles: true,
+  showAxisTitles: {
+    x: true,
+    y: true,
+    y2: true,
+  },
+  axisTitles: {
+    x: '',
+    y: '',
+    y2: '',
+  },
   showCurrency: false,
   formatData: {},
   hoverInfo: '',

--- a/src/components/plotly/bar-line/index.js
+++ b/src/components/plotly/bar-line/index.js
@@ -108,8 +108,16 @@ BarLine.propTypes = {
   x: PropTypes.string.isRequired,
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
-  axisTitles: PropTypes.objectOf(PropTypes.string),
+  showAxisTitles: PropTypes.shape({
+    x: PropTypes.bool,
+    y: PropTypes.bool,
+    y2: PropTypes.bool,
+  }),
+  axisTitles: PropTypes.shape({
+    x: PropTypes.string,
+    y: PropTypes.string,
+    y2: PropTypes.string,
+  }),
   showCurrency: PropTypes.bool,
   formatData: PropTypes.objectOf(PropTypes.func),
   hoverInfo: PropTypes.string,

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -12,6 +12,7 @@ const Bar = ({
   stacked,
   showTicks,
   showAxisTitles,
+  axisTitles,
   x,
   y,
   orientation,
@@ -24,7 +25,6 @@ const Bar = ({
   hoverText,
   ...props
 }) => {
-
   const _data = useTransformedData({
     type: 'bar',
     data,
@@ -50,8 +50,8 @@ const Bar = ({
           ticksuffix: tickSuffix[0] || orientation === 'h' && showPercentage && '%',
           tickprefix: tickPrefix[0],
           automargin: true,
-          ...(showAxisTitles && {
-            title: getAxisTitle(orientation, 'v', x, y),
+          ...(showAxisTitles.x && {
+            title: axisTitles.x || getAxisTitle(orientation, 'v', x, y),
           }),
         },
         yaxis: {
@@ -59,8 +59,11 @@ const Bar = ({
           ticksuffix: tickSuffix[1] || orientation === 'v' && showPercentage && '%',
           tickprefix: tickPrefix[1],
           automargin: true,
-          ...(showAxisTitles && {
-            title: getAxisTitle(orientation, 'h', x, y),
+          ...(showAxisTitles.y && {
+            title: {
+              text: axisTitles.y || getAxisTitle(orientation, 'h', x, y),
+              standoff: 30,
+            },
           }),
         },
         margin: {
@@ -81,7 +84,8 @@ Bar.propTypes = {
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   stacked: PropTypes.bool,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.bool,
+  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
+  axisTitles: PropTypes.objectOf(PropTypes.string),
   showPercentage: PropTypes.bool,
   orientation: PropTypes.oneOf(['v', 'h']),
   textPosition: PropTypes.oneOf(['inside', 'outside', 'auto', 'none']),
@@ -99,7 +103,14 @@ Bar.propTypes = {
 Bar.defaultProps = {
   stacked: false,
   showTicks: true,
-  showAxisTitles: true,
+  showAxisTitles: {
+    x: true,
+    y: true,
+  },
+  axisTitles: {
+    x: '',
+    y: '',
+  },
   showPercentage: false,
   orientation: 'v',
   textPosition: 'outside',

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -51,7 +51,7 @@ const Bar = ({
           tickprefix: tickPrefix[0],
           automargin: true,
           ...(showAxisTitles.x && {
-            title: axisTitles.x || getAxisTitle(orientation, 'v', x, y),
+            title: getAxisTitle(orientation, 'v', axisTitles.x || x, y),
           }),
         },
         yaxis: {
@@ -60,10 +60,7 @@ const Bar = ({
           tickprefix: tickPrefix[1],
           automargin: true,
           ...(showAxisTitles.y && {
-            title: {
-              text: axisTitles.y || getAxisTitle(orientation, 'h', x, y),
-              standoff: 30,
-            },
+            title: getAxisTitle(orientation, 'h', x, axisTitles.y ? [axisTitles.y] : y),
           }),
         },
         margin: {

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -81,8 +81,14 @@ Bar.propTypes = {
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   stacked: PropTypes.bool,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
-  axisTitles: PropTypes.objectOf(PropTypes.string),
+  showAxisTitles: PropTypes.shape({
+    x: PropTypes.bool,
+    y: PropTypes.bool,
+  }),
+  axisTitles: PropTypes.shape({
+    x: PropTypes.string,
+    y: PropTypes.string,
+  }),
   showPercentage: PropTypes.bool,
   orientation: PropTypes.oneOf(['v', 'h']),
   textPosition: PropTypes.oneOf(['inside', 'outside', 'auto', 'none']),

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -51,7 +51,7 @@ const Bar = ({
           tickprefix: tickPrefix[0],
           automargin: true,
           ...(showAxisTitles.x && {
-            title: getAxisTitle(orientation, 'v', axisTitles.x || x, y),
+            title: getAxisTitle(orientation, 'v', axisTitles.x || x, axisTitles.y ? [axisTitles.y] : y),
           }),
         },
         yaxis: {
@@ -60,7 +60,7 @@ const Bar = ({
           tickprefix: tickPrefix[1],
           automargin: true,
           ...(showAxisTitles.y && {
-            title: getAxisTitle(orientation, 'h', x, axisTitles.y ? [axisTitles.y] : y),
+            title: getAxisTitle(orientation, 'h', axisTitles.x || x, axisTitles.y ? [axisTitles.y] : y),
           }),
         },
         margin: {

--- a/src/components/plotly/line/index.js
+++ b/src/components/plotly/line/index.js
@@ -75,8 +75,14 @@ Line.propTypes = {
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   spline: PropTypes.bool,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
-  axisTitles: PropTypes.objectOf(PropTypes.string),
+  showAxisTitles: PropTypes.shape({
+    x: PropTypes.bool,
+    y: PropTypes.bool,
+  }),
+  axisTitles: PropTypes.shape({
+    x: PropTypes.string,
+    y: PropTypes.string,
+  }),
   formatData: PropTypes.objectOf(PropTypes.func),
   tickSuffix: PropTypes.arrayOf(PropTypes.string),
   tickPrefix: PropTypes.arrayOf(PropTypes.string),

--- a/src/components/plotly/line/index.js
+++ b/src/components/plotly/line/index.js
@@ -11,6 +11,7 @@ const Line = ({
   spline,
   showTicks,
   showAxisTitles,
+  axisTitles,
   x,
   y,
   formatData,
@@ -45,9 +46,9 @@ const Line = ({
         automargin: true,
         ticksuffix: tickSuffix[0],
         tickprefix: tickPrefix[0],
-        ...(showAxisTitles && {
+        ...(showAxisTitles.x && {
           title: {
-            text: x,
+            text: axisTitles.x || x,
             standoff: 20,
           },
         }),
@@ -57,9 +58,9 @@ const Line = ({
         automargin: true,
         ticksuffix: tickSuffix[1],
         tickprefix: tickPrefix[1],
-        ...(showAxisTitles && y?.length === 1 && {
+        ...(showAxisTitles.y && (axisTitles.y || y?.length === 1) && {
           title: {
-            text: y[0],
+            text: axisTitles.y || y[0],
             standoff: 30,
           },
         }),
@@ -74,7 +75,8 @@ Line.propTypes = {
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   spline: PropTypes.bool,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.bool,
+  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
+  axisTitles: PropTypes.objectOf(PropTypes.string),
   formatData: PropTypes.objectOf(PropTypes.func),
   tickSuffix: PropTypes.arrayOf(PropTypes.string),
   tickPrefix: PropTypes.arrayOf(PropTypes.string),
@@ -89,7 +91,14 @@ Line.propTypes = {
 Line.defaultProps = {
   spline: false,
   showTicks: true,
-  showAxisTitles: true,
+  showAxisTitles: {
+    x: true,
+    y: true,
+  },
+  axisTitles: {
+    x: '',
+    y: '',
+  },
   formatData: {},
   tickSuffix: [],
   tickPrefix: [],

--- a/src/components/plotly/pie/index.js
+++ b/src/components/plotly/pie/index.js
@@ -18,25 +18,24 @@ const Pie = ({
   hoverInfo,
   hoverText,
   ...props
-}) => {
-  return (
-    <CustomPlot
-      type='pie'
-      data={useTransformedData({
-        type: 'pie',
-        data,
-        extra: {
-          textinfo: textinfo ?? getTextInfo({ showPercentage, showLabelName }),
-          hole: hole ?? (donut ? 0.4 : 0),
-        },
-        formatData,
-        hoverInfo,
-        hoverText,
-        ...props,
-      })}
-      {...props}
-    />
-  )}
+}) => (
+  <CustomPlot
+    type='pie'
+    data={useTransformedData({
+      type: 'pie',
+      data,
+      extra: {
+        textinfo: textinfo ?? getTextInfo({ showPercentage, showLabelName }),
+        hole: hole ?? (donut ? 0.4 : 0),
+      },
+      formatData,
+      hoverInfo,
+      hoverText,
+      ...props,
+    })}
+    {...props}
+  />
+)
 
 Pie.propTypes = {
   label: PropTypes.string.isRequired,

--- a/src/components/plotly/pyramid-bar/index.js
+++ b/src/components/plotly/pyramid-bar/index.js
@@ -116,8 +116,14 @@ PyramidBar.propTypes = {
   x: PropTypes.arrayOf(PropTypes.string).isRequired,
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
-  axisTitles: PropTypes.objectOf(PropTypes.string),
+  showAxisTitles: PropTypes.shape({
+    x: PropTypes.bool,
+    y: PropTypes.bool,
+  }),
+  axisTitles: PropTypes.shape({
+    x: PropTypes.string,
+    y: PropTypes.string,
+  }),
   showPercentage: PropTypes.bool,
   xAxisTick: PropTypes.arrayOf(PropTypes.number),
   xAxisLabelLength: PropTypes.number,

--- a/src/components/plotly/pyramid-bar/index.js
+++ b/src/components/plotly/pyramid-bar/index.js
@@ -15,7 +15,7 @@ const PyramidBar = ({
   x,
   y,
   showPercentage,
-  axisLabel,
+  axisTitles,
   xAxisTick,
   xAxisLabelLength,
   textPosition,
@@ -26,7 +26,6 @@ const PyramidBar = ({
   hoverText,
   ...props
 }) => {
-
   const _data = useTransformedData({
     type: 'bar',
     data,
@@ -64,7 +63,6 @@ const PyramidBar = ({
     }
 
     return { tickText, positive: xValReverse, negative: axisTicks.map(val => -Math.abs(val)) }
-
   }
 
   const maxValue = getMaxRange(_data, false, 'pyramid')
@@ -87,9 +85,9 @@ const PyramidBar = ({
           tickvals: [...getXaxisTicks.negative, 0, ...getXaxisTicks.positive],
           ticksuffix: tickSuffix[0],
           tickprefix: tickPrefix[0],
-          ...(showAxisTitles && {
+          ...(showAxisTitles.x && {
             title: {
-              text: axisLabel[0],
+              text: axisTitles.x,
               standoff: 20,
             },
           }),
@@ -101,10 +99,10 @@ const PyramidBar = ({
           autorange: true,
           ticksuffix: tickSuffix[1],
           tickprefix: tickPrefix[1],
-          ...(showAxisTitles && {
+          ...(showAxisTitles.y && {
             title: {
-              text: axisLabel[1] || Object.keys(data[0])[0],
-              standoff: 20,
+              text: axisTitles.y || Object.keys(data[0])[0],
+              standoff: 30,
             },
           }),
         },
@@ -118,9 +116,9 @@ PyramidBar.propTypes = {
   x: PropTypes.arrayOf(PropTypes.string).isRequired,
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.bool,
+  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
+  axisTitles: PropTypes.objectOf(PropTypes.string),
   showPercentage: PropTypes.bool,
-  axisLabel: PropTypes.arrayOf(PropTypes.string),
   xAxisTick: PropTypes.arrayOf(PropTypes.number),
   xAxisLabelLength: PropTypes.number,
   textPosition: PropTypes.oneOf(['inside', 'outside', 'auto', 'none']),
@@ -137,9 +135,15 @@ PyramidBar.propTypes = {
 
 PyramidBar.defaultProps = {
   showTicks: true,
-  showAxisTitles: true,
+  showAxisTitles: {
+    x: true,
+    y: true,
+  },
+  axisTitles: {
+    x: 'count',
+    y: '',
+  },
   showPercentage: false,
-  axisLabel: ['count'],
   xAxisTick: [],
   xAxisLabelLength: 5,
   textPosition: 'outside',

--- a/src/components/plotly/scatter/index.js
+++ b/src/components/plotly/scatter/index.js
@@ -11,6 +11,7 @@ const Scatter = ({
   showTicks,
   showLines,
   showAxisTitles,
+  axisTitles,
   x,
   y,
   formatData,
@@ -43,9 +44,9 @@ const Scatter = ({
         automargin: true,
         ticksuffix: tickSuffix[0],
         tickprefix: tickPrefix[0],
-        ...(showAxisTitles && {
+        ...(showAxisTitles.x && {
           title: {
-            text: x,
+            text: axisTitles.x || x,
             standoff: 20,
           },
         }),
@@ -55,9 +56,9 @@ const Scatter = ({
         automargin: true,
         ticksuffix: tickSuffix[1],
         tickprefix: tickPrefix[1],
-        ...(showAxisTitles && y?.length === 1 && {
+        ...(showAxisTitles.y && (axisTitles.y || y?.length === 1) && {
           title: {
-            text: y[0],
+            text: axisTitles.y || y[0],
             standoff: 30,
           },
         }),
@@ -79,7 +80,8 @@ Scatter.propTypes = {
   x: PropTypes.string.isRequired,
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.bool,
+  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
+  axisTitles: PropTypes.objectOf(PropTypes.string),
   formatData: PropTypes.objectOf(PropTypes.func),
   tickSuffix: PropTypes.arrayOf(PropTypes.string),
   tickPrefix: PropTypes.arrayOf(PropTypes.string),
@@ -93,7 +95,14 @@ Scatter.propTypes = {
 
 Scatter.defaultProps = {
   showTicks: true,
-  showAxisTitles: true,
+  showAxisTitles: {
+    x: true,
+    y: true,
+  },
+  axisTitles: {
+    x: '',
+    y: '',
+  },
   formatData: {},
   tickSuffix: [],
   tickPrefix: [],

--- a/src/components/plotly/scatter/index.js
+++ b/src/components/plotly/scatter/index.js
@@ -80,8 +80,14 @@ Scatter.propTypes = {
   x: PropTypes.string.isRequired,
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
-  axisTitles: PropTypes.objectOf(PropTypes.string),
+  showAxisTitles: PropTypes.shape({
+    x: PropTypes.bool,
+    y: PropTypes.bool,
+  }),
+  axisTitles: PropTypes.shape({
+    x: PropTypes.string,
+    y: PropTypes.string,
+  }),
   formatData: PropTypes.objectOf(PropTypes.func),
   tickSuffix: PropTypes.arrayOf(PropTypes.string),
   tickPrefix: PropTypes.arrayOf(PropTypes.string),

--- a/stories/plotly/plotly-bar-line.stories.js
+++ b/stories/plotly/plotly-bar-line.stories.js
@@ -20,3 +20,9 @@ const Template = (args) =>
 
 export const Default = Template.bind({})
 Default.args = { showCurrency: true }
+
+export const CustomAxisTitles = Template.bind({})
+CustomAxisTitles.args= {
+  showAxisTitles: { x: true, y: false, y2: true },
+  axisTitles: { x: 'Canadian City', y2: 'Score' },
+}

--- a/stories/plotly/plotly-bar.stories.js
+++ b/stories/plotly/plotly-bar.stories.js
@@ -31,7 +31,7 @@ const FormattingTemplate = (args) =>
         'hh_income_50_100k', 
         'hh_income_100_150k',
         'hh_income_150_200k',
-        'hh_income_200k+'
+        'hh_income_200k+',
       ]}
       {...args}
     />

--- a/stories/plotly/plotly-bar.stories.js
+++ b/stories/plotly/plotly-bar.stories.js
@@ -39,6 +39,9 @@ const FormattingTemplate = (args) =>
 
 export const Default = Template.bind({})
 
+export const CustomAxisTitles = Template.bind({})
+CustomAxisTitles.args= { axisTitles: { y: 'Score' } }
+
 export const Stacked = Template.bind({})
 Stacked.args = { stacked: true }
 
@@ -59,7 +62,7 @@ HorizontalFormatted.args = {
     'hh_income_50_100k': formatting,
     'hh_income_100_150k': formatting,
     'hh_income_150_200k': formatting,
-    'hh_income_200k+': formatting
+    'hh_income_200k+': formatting,
   },
   tickSuffix: ['%'],
 }

--- a/stories/plotly/plotly-bar.stories.js
+++ b/stories/plotly/plotly-bar.stories.js
@@ -51,8 +51,16 @@ PercentageLabel.args = { showPercentage: true }
 export const Horizontal = Template.bind({})
 Horizontal.args = { orientation: 'h' }
 
+export const HorizontalCustomAxisTitles = Template.bind({})
+Horizontal.args = { orientation: 'h' }
+
 export const HorizontalStacked = Template.bind({})
-HorizontalStacked.args = { orientation: 'h', stacked: true }
+HorizontalCustomAxisTitles.args = {
+  orientation: 'h',
+  stacked: true.valueOf,
+  showAxisTitles: { x: true },
+  axisTitles: { y: 'Impressions' },
+}
 
 export const HorizontalFormatted = FormattingTemplate.bind({})
 HorizontalFormatted.args = { 

--- a/stories/plotly/plotly-line.stories.js
+++ b/stories/plotly/plotly-line.stories.js
@@ -20,5 +20,8 @@ const Template = (args) =>
 
 export const Default = Template.bind({})
 
+export const CustomAxisTitles = Template.bind({})
+CustomAxisTitles.args= { axisTitles: { x: 'Stat', y: '%' } }
+
 export const Spline = Template.bind({})
 Spline.args = { spline: true }

--- a/stories/plotly/plotly-pyramid-bar.stories.js
+++ b/stories/plotly/plotly-pyramid-bar.stories.js
@@ -14,7 +14,7 @@ export default {
  * [showTicks] - bool, control ticks display in the chart, default = true
  * [showAxisTitles] - bool, control axisTitles display in the chart, default = true
  * [showPercentage] - bool, control value display format in the chart, default = false
- * [axisLabel] - array of string, defines the chart axis label/title to be displayed, [xAxis, yAxis], default = ['count']
+ * [axisTitles] - array of string, defines the chart axis label/title to be displayed, [xAxis, yAxis], default = ['count']
  * [xAxisTick] - array of numbers, defines the range value of 'x' data to be displayed in the chart.
  * [xAxisLabelLength] - number, defines de number of tick in xAxis. Only works if there is not xAxisTick
  * [textPosition] - string, defines the text position inside each bar graph, default = 'outside'. only ['inside', 'outside', 'auto', 'none']
@@ -35,8 +35,11 @@ const Template = (args) =>
 
 export const Default = Template.bind({})
 
+export const CustomAxisTitles = Template.bind({})
+CustomAxisTitles.args= { axisTitles: { x: 'Count', y: 'Age Group' } }
+
 export const Percentage = Template.bind({})
 Percentage.args = { showPercentage: true }
 
 export const CustomXaxisTick = Template.bind({})
-CustomXaxisTick.args = { xAxisTick: [1000, 600, 300]}
+CustomXaxisTick.args = { xAxisTick: [1000, 600, 300] }

--- a/stories/plotly/plotly-scatter.stories.js
+++ b/stories/plotly/plotly-scatter.stories.js
@@ -20,5 +20,8 @@ const Template = (args) =>
 
 export const Default = Template.bind({})
 
+export const CustomAxisTitles = Template.bind({})
+CustomAxisTitles.args= { axisTitles: { x: 'Stat', y: 'Score' } }
+
 export const WithLines = Template.bind({})
 WithLines.args = { showLines: true }


### PR DESCRIPTION
Closes #192

**Problem:**
We need customization on two fronts in plotly charts:

1. The ability to hide axis titles independently of each other
2. The possibility to add custom titles to x & y axes separately

**Example:**
In the Figma file below, we have the x-axis title hidden, and, for y-axis we need to display the symbol `%`
<img width="663" alt="Screen Shot 2022-10-06 at 4 59 37 PM" src="https://user-images.githubusercontent.com/41120953/194423625-f4b9acfd-2202-40a9-876c-f9f18781e489.png">


**Solution:**
<img width="997" alt="Screen Shot 2022-10-06 at 5 04 51 PM" src="https://user-images.githubusercontent.com/41120953/194418514-56eb1636-1f6e-4460-8aa7-90d96ba23ce0.png">

Stories to test:
https://60f5a69eddb5b90039b6d17c-ffvuhynubo.chromatic.com/?path=/story/plotly-bar--custom-axis-titles
https://60f5a69eddb5b90039b6d17c-ffvuhynubo.chromatic.com/?path=/story/plotly-line--custom-axis-titles
https://60f5a69eddb5b90039b6d17c-ffvuhynubo.chromatic.com/?path=/story/plotly-pyramid-bar--custom-axis-titles
https://60f5a69eddb5b90039b6d17c-ffvuhynubo.chromatic.com/?path=/story/plotly-scatter--custom-axis-titles
