### PR TITLE
[G2M] Plotly - fix custom axis title for plotly Bar chart; add custom axis titles for BarLine chart

### DIFF
--- a/src/components/plotly/bar-line/index.js
+++ b/src/components/plotly/bar-line/index.js
@@ -34,12 +34,12 @@ const BarLine = ({
     })[0],
   }
 
-  const scatter_data = {
-    type: 'scatter',
+  const line_data = {
+    type: 'line',
     yaxis: 'y2',
     connectgaps: true,
     ...useTransformedData({
-      type: 'scatter',
+      type: 'line',
       data,
       x,
       y: [y[1] ? y[1] : y[0]],
@@ -59,7 +59,7 @@ const BarLine = ({
       <CustomPlot
         type='barline'
         data={y[1] ? [
-          scatter_data,
+          line_data,
           bar_data,
         ] : [bar_data]}
         layout={{
@@ -67,6 +67,7 @@ const BarLine = ({
             showticklabels: showTicks,
             tickmode: 'linear',
             tickformat: '%b %d',
+            automargin: true,
             ...(showAxisTitles.x && {
               title: {
                 standoff: 20,

--- a/src/components/plotly/bar-line/index.js
+++ b/src/components/plotly/bar-line/index.js
@@ -10,6 +10,7 @@ const BarLine = ({
   data,
   showTicks,
   showAxisTitles,
+  axisTitles,
   x,
   y,
   showCurrency,
@@ -66,12 +67,18 @@ const BarLine = ({
             showticklabels: showTicks,
             tickmode: 'linear',
             tickformat: '%b %d',
-          },
-          yaxis: {
-            ...(showAxisTitles && y[0] && { 
+            ...(showAxisTitles.x && {
               title: {
                 standoff: 20,
-                text: y[0],
+                text: axisTitles.x || x,
+              },
+            }),
+          },
+          yaxis: {
+            ...(showAxisTitles.y && y[0] && {
+              title: {
+                standoff: 20,
+                text: axisTitles.y || y[0],
               },
             }),
             showticklabels: showTicks,
@@ -80,10 +87,10 @@ const BarLine = ({
             overlaying: 'y2',
           },
           yaxis2: {
-            ...(showAxisTitles && y[1] && { 
+            ...(showAxisTitles.y2 && y[1] && {
               title: {
                 standoff: 20,
-                text: y[1],
+                text: axisTitles.y2 || y[1],
               },
             }),
             showticklabels: showTicks,
@@ -100,7 +107,8 @@ BarLine.propTypes = {
   x: PropTypes.string.isRequired,
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.bool,
+  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
+  axisTitles: PropTypes.objectOf(PropTypes.string),
   showCurrency: PropTypes.bool,
   formatData: PropTypes.objectOf(PropTypes.func),
   hoverInfo: PropTypes.string,
@@ -113,7 +121,16 @@ BarLine.propTypes = {
 
 BarLine.defaultProps = {
   showTicks: true,
-  showAxisTitles: true,
+  showAxisTitles: {
+    x: true,
+    y: true,
+    y2: true,
+  },
+  axisTitles: {
+    x: '',
+    y: '',
+    y2: '',
+  },
   showCurrency: false,
   formatData: {},
   hoverInfo: '',

--- a/src/components/plotly/bar-line/index.js
+++ b/src/components/plotly/bar-line/index.js
@@ -108,8 +108,16 @@ BarLine.propTypes = {
   x: PropTypes.string.isRequired,
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
-  axisTitles: PropTypes.objectOf(PropTypes.string),
+  showAxisTitles: PropTypes.shape({
+    x: PropTypes.bool,
+    y: PropTypes.bool,
+    y2: PropTypes.bool,
+  }),
+  axisTitles: PropTypes.shape({
+    x: PropTypes.string,
+    y: PropTypes.string,
+    y2: PropTypes.string,
+  }),
   showCurrency: PropTypes.bool,
   formatData: PropTypes.objectOf(PropTypes.func),
   hoverInfo: PropTypes.string,

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -51,7 +51,7 @@ const Bar = ({
           tickprefix: tickPrefix[0],
           automargin: true,
           ...(showAxisTitles.x && {
-            title: axisTitles.x || getAxisTitle(orientation, 'v', x, y),
+            title: getAxisTitle(orientation, 'v', axisTitles.x || x, y),
           }),
         },
         yaxis: {
@@ -60,10 +60,7 @@ const Bar = ({
           tickprefix: tickPrefix[1],
           automargin: true,
           ...(showAxisTitles.y && {
-            title: {
-              text: axisTitles.y || getAxisTitle(orientation, 'h', x, y),
-              standoff: 30,
-            },
+            title: getAxisTitle(orientation, 'h', x, axisTitles.y ? [axisTitles.y] : y),
           }),
         },
         margin: {

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -81,8 +81,14 @@ Bar.propTypes = {
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   stacked: PropTypes.bool,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
-  axisTitles: PropTypes.objectOf(PropTypes.string),
+  showAxisTitles: PropTypes.shape({
+    x: PropTypes.bool,
+    y: PropTypes.bool,
+  }),
+  axisTitles: PropTypes.shape({
+    x: PropTypes.string,
+    y: PropTypes.string,
+  }),
   showPercentage: PropTypes.bool,
   orientation: PropTypes.oneOf(['v', 'h']),
   textPosition: PropTypes.oneOf(['inside', 'outside', 'auto', 'none']),

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -51,7 +51,7 @@ const Bar = ({
           tickprefix: tickPrefix[0],
           automargin: true,
           ...(showAxisTitles.x && {
-            title: getAxisTitle(orientation, 'v', axisTitles.x || x, y),
+            title: getAxisTitle(orientation, 'v', axisTitles.x || x, axisTitles.y ? [axisTitles.y] : y),
           }),
         },
         yaxis: {
@@ -60,7 +60,7 @@ const Bar = ({
           tickprefix: tickPrefix[1],
           automargin: true,
           ...(showAxisTitles.y && {
-            title: getAxisTitle(orientation, 'h', x, axisTitles.y ? [axisTitles.y] : y),
+            title: getAxisTitle(orientation, 'h', axisTitles.x || x, axisTitles.y ? [axisTitles.y] : y),
           }),
         },
         margin: {

--- a/src/components/plotly/line/index.js
+++ b/src/components/plotly/line/index.js
@@ -75,8 +75,14 @@ Line.propTypes = {
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   spline: PropTypes.bool,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
-  axisTitles: PropTypes.objectOf(PropTypes.string),
+  showAxisTitles: PropTypes.shape({
+    x: PropTypes.bool,
+    y: PropTypes.bool,
+  }),
+  axisTitles: PropTypes.shape({
+    x: PropTypes.string,
+    y: PropTypes.string,
+  }),
   formatData: PropTypes.objectOf(PropTypes.func),
   tickSuffix: PropTypes.arrayOf(PropTypes.string),
   tickPrefix: PropTypes.arrayOf(PropTypes.string),

--- a/src/components/plotly/pyramid-bar/index.js
+++ b/src/components/plotly/pyramid-bar/index.js
@@ -116,8 +116,14 @@ PyramidBar.propTypes = {
   x: PropTypes.arrayOf(PropTypes.string).isRequired,
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
-  axisTitles: PropTypes.objectOf(PropTypes.string),
+  showAxisTitles: PropTypes.shape({
+    x: PropTypes.bool,
+    y: PropTypes.bool,
+  }),
+  axisTitles: PropTypes.shape({
+    x: PropTypes.string,
+    y: PropTypes.string,
+  }),
   showPercentage: PropTypes.bool,
   xAxisTick: PropTypes.arrayOf(PropTypes.number),
   xAxisLabelLength: PropTypes.number,

--- a/src/components/plotly/scatter/index.js
+++ b/src/components/plotly/scatter/index.js
@@ -80,8 +80,14 @@ Scatter.propTypes = {
   x: PropTypes.string.isRequired,
   y: PropTypes.arrayOf(PropTypes.string).isRequired,
   showTicks: PropTypes.bool,
-  showAxisTitles: PropTypes.objectOf(PropTypes.bool),
-  axisTitles: PropTypes.objectOf(PropTypes.string),
+  showAxisTitles: PropTypes.shape({
+    x: PropTypes.bool,
+    y: PropTypes.bool,
+  }),
+  axisTitles: PropTypes.shape({
+    x: PropTypes.string,
+    y: PropTypes.string,
+  }),
   formatData: PropTypes.objectOf(PropTypes.func),
   tickSuffix: PropTypes.arrayOf(PropTypes.string),
   tickPrefix: PropTypes.arrayOf(PropTypes.string),

--- a/stories/plotly/plotly-bar-line.stories.js
+++ b/stories/plotly/plotly-bar-line.stories.js
@@ -20,3 +20,9 @@ const Template = (args) =>
 
 export const Default = Template.bind({})
 Default.args = { showCurrency: true }
+
+export const CustomAxisTitles = Template.bind({})
+CustomAxisTitles.args= {
+  showAxisTitles: { x: true, y: false, y2: true },
+  axisTitles: { x: 'Canadian City', y2: 'Score' },
+}

--- a/stories/plotly/plotly-bar.stories.js
+++ b/stories/plotly/plotly-bar.stories.js
@@ -51,8 +51,16 @@ PercentageLabel.args = { showPercentage: true }
 export const Horizontal = Template.bind({})
 Horizontal.args = { orientation: 'h' }
 
+export const HorizontalCustomAxisTitles = Template.bind({})
+Horizontal.args = { orientation: 'h' }
+
 export const HorizontalStacked = Template.bind({})
-HorizontalStacked.args = { orientation: 'h', stacked: true }
+HorizontalCustomAxisTitles.args = {
+  orientation: 'h',
+  stacked: true.valueOf,
+  showAxisTitles: { x: true },
+  axisTitles: { y: 'Impressions' },
+}
 
 export const HorizontalFormatted = FormattingTemplate.bind({})
 HorizontalFormatted.args = { 


### PR DESCRIPTION
**Changes:**
### Plotly/Bar

1. Fixed custom title for plotly Bar chart
2. Added story for horizontal bar chart with custom axis titles

<img width="649" alt="Screen Shot 2022-10-12 at 12 46 15 PM" src="https://user-images.githubusercontent.com/41120953/195401459-821defd8-2717-4df1-8042-688201e2e8c4.png">

[Test Story](https://60f5a69eddb5b90039b6d17c-nheqlcgjdn.chromatic.com/?path=/story/plotly-bar--horizontal-custom-axis-titles)

### Plotly/BarLine

1. Added custom `x-axis` props for display & title text
<img width="973" alt="Screen Shot 2022-10-12 at 10 16 07 AM" src="https://user-images.githubusercontent.com/41120953/195368389-28080553-db77-40f9-98ae-9c1826b4ddc4.png">

3. Added x-axis title & fix positioning of the title
**Before:**
<img width="973" alt="Screen Shot 2022-10-12 at 10 07 14 AM" src="https://user-images.githubusercontent.com/41120953/195368714-bd7cf921-5dfd-4a0a-b801-cbf4d4f276f9.png">

[Test Story](https://60f5a69eddb5b90039b6d17c-ebjgpqscuj.chromatic.com/?path=/story/plotly-bar-line--custom-axis-titles)

