### PR TITLE
[G2M] Plotly charts - add custom colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/chart-system",
   "private": false,
-  "version": "0.9.2",
+  "version": "0.9.3",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/src/components/plotly/shared/custom-plot.js
+++ b/src/components/plotly/shared/custom-plot.js
@@ -26,6 +26,7 @@ const CustomPlot = ({
   showSubPlotTitles,
   title,
   baseColor,
+  customColors,
   showLegend,
   onAfterPlot,
 }) => {
@@ -52,8 +53,11 @@ const CustomPlot = ({
   // determine the keys for the legend
   const legendKeys = useMemo(() => plotlyInterfaces[type].getLegendKeys(data), [data, type])
 
-  // generate the color scheme based on a single base color
-  const colors = useMemo(() => getColorScheme(baseColor, legendKeys.length), [baseColor, legendKeys.length])
+  // use customColors or generate the color scheme based on a single base color
+  const colors = useMemo(() => customColors.length
+    ? customColors
+    : getColorScheme(baseColor, legendKeys.length)
+  , [customColors, baseColor, legendKeys.length])
 
   // enrich the data with color values
   const coloredData = useMemo(() => (
@@ -206,6 +210,7 @@ CustomPlot.propTypes = {
   showSubPlotTitles: PropTypes.bool,
   size: PropTypes.number,
   baseColor: PropTypes.string,
+  customColors: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string,
   onAfterPlot: PropTypes.func,
 }
@@ -219,6 +224,7 @@ CustomPlot.defaultProps = {
   showSubPlotTitles: true,
   size: 0.8,
   baseColor: '#0017ff',
+  customColors: [],
   showLegend: true,
   title: null,
   onAfterPlot: () => {},

--- a/stories/plotly/plotly-pie.stories.js
+++ b/stories/plotly/plotly-pie.stories.js
@@ -40,3 +40,6 @@ Donut.args = { donut: true }
 
 export const NoLabels = Template.bind({})
 NoLabels.args = { showPercentage: false }
+
+export const CustomColors = Template.bind({})
+CustomColors.args = { customColors: ['#88CCEE', '#CC6677', '#DDCC77', '#477733', '#0F2288'] }


### PR DESCRIPTION
**Changes:**

### Plotly charts - CustomPlot

- added `customColors` prop to be preferably used over `baseColor` in plotly charts

[Test story](https://60f5a69eddb5b90039b6d17c-eeobrfdixb.chromatic.com/?path=/story/plotly-pie--custom-colors)