### PR TITLE
[G2M] Plotly - add columnNameAliases prop & code logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eqworks/chart-system",
   "private": false,
-  "version": "0.9.8",
+  "version": "0.10.0",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/src/components/d3/cluster.js
+++ b/src/components/d3/cluster.js
@@ -100,6 +100,7 @@ const Cluster = ({ width, height, data, config }) => {
             .remove()
         })
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [svgRef.current, clusters, currentGroup ])
 
   return (

--- a/src/components/d3/gauge-arc.js
+++ b/src/components/d3/gauge-arc.js
@@ -20,6 +20,7 @@ const GaugeArc = ({ data, width, height, config }) => {
 
   const arcsGenerator = d3.pie().sortValues(function (a, b) { return isAscending ? b - a : a - b })
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const arcsData = useMemo(() => arcsGenerator([value, remainder]), [value, remainder])
 
   const arcPath = d3.arc().innerRadius(pieSize - lineThickness).outerRadius(pieSize).cornerRadius(lineThickness)
@@ -53,6 +54,7 @@ const GaugeArc = ({ data, width, height, config }) => {
           })
       }
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [svgRef.current, arcsData])
 
   return (

--- a/src/components/plotly/bar-line/index.js
+++ b/src/components/plotly/bar-line/index.js
@@ -35,6 +35,7 @@ const BarLine = ({
   showLineMarkers,
   sharedYAxis,
   lineFill,
+  columnNameAliases,
   ...props
 }) => {
   const bar_ = useTransformedData({
@@ -42,6 +43,7 @@ const BarLine = ({
     data,
     x,
     y,
+    columnNameAliases,
     orientation: 'v',
     textPosition: 'none',
     formatData,
@@ -57,6 +59,7 @@ const BarLine = ({
     data,
     x,
     y: y2,
+    columnNameAliases,
     formatData,
     tickSuffix: tickSuffix[1],
     tickPrefix: tickPrefix[1],
@@ -86,7 +89,7 @@ const BarLine = ({
             ...(showAxisTitles.x && {
               title: {
                 standoff: 20,
-                text: axisTitles.x || x,
+                text: axisTitles.x || columnNameAliases[x] || x,
               },
             }),
           },
@@ -100,7 +103,7 @@ const BarLine = ({
             ...(showAxisTitles.y && {
               title: {
                 standoff: 20,
-                text: axisTitles.y || y[0],
+                text: axisTitles.y || columnNameAliases[y[0]] || y[0],
               },
             }),
           },
@@ -115,7 +118,7 @@ const BarLine = ({
             ...(showAxisTitles.y2 && {
               title: {
                 standoff: 20,
-                text: axisTitles.y2 || y2[0],
+                text: axisTitles.y2 || columnNameAliases[y2[0]] || y2[0],
               },
             }),
           },
@@ -168,6 +171,7 @@ BarLine.propTypes = {
   showLineMarkers: PropTypes.bool,
   sharedYAxis: PropTypes.bool,
   lineFill: PropTypes.bool,
+  columnNameAliases: PropTypes.object,
   ...plotlyPropTypes,
 }
 
@@ -202,6 +206,7 @@ BarLine.defaultProps = {
   showLineMarkers: false,
   sharedYAxis: true,
   lineFill: false,
+  columnNameAliases: {},
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/bar/index.js
+++ b/src/components/plotly/bar/index.js
@@ -23,6 +23,7 @@ const Bar = ({
   hoverInfo,
   hoverText,
   onAfterPlot,
+  columnNameAliases,
   ...props
 }) => {
   const _data = useTransformedData({
@@ -30,6 +31,7 @@ const Bar = ({
     data,
     x,
     y,
+    columnNameAliases,
     orientation,
     textPosition,
     formatData,
@@ -54,7 +56,7 @@ const Bar = ({
           automargin: true,
           ...(showAxisTitles.x && {
             title: {
-              text: axisTitles.x || x,
+              text: axisTitles.x || columnNameAliases[x] || x,
               standoff: 20,
             },
           }),
@@ -66,7 +68,7 @@ const Bar = ({
           automargin: true,
           ...(showAxisTitles.y && {
             title: {
-              text: axisTitles.y ? axisTitles.y : y[0],
+              text: axisTitles.y || columnNameAliases[y[0]] || y[0],
               standoff: 20,
             },
           }),
@@ -109,6 +111,7 @@ Bar.propTypes = {
     PropTypes.string,
   ]),
   onAfterPlot: PropTypes.func,
+  columnNameAliases: PropTypes.object,
   ...plotlyPropTypes,
 }
 
@@ -131,6 +134,7 @@ Bar.defaultProps = {
   hoverInfo: '',
   hoverText: '',
   onAfterPlot: () => {},
+  columnNameAliases: {},
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/double-line/index.js
+++ b/src/components/plotly/double-line/index.js
@@ -20,6 +20,7 @@ const DoubleLine = ({
   hoverText,
   mode,
   onAfterPlot,
+  columnNameAliases,
   ...props
 }) => {
   const line_data1 = {
@@ -30,6 +31,7 @@ const DoubleLine = ({
       data,
       x,
       y: [y[0]],
+      columnNameAliases,
       formatData,
       tickSuffix,
       tickPrefix,
@@ -52,6 +54,7 @@ const DoubleLine = ({
       data,
       x,
       y: [y[1] ? y[1] : y[0]],
+      columnNameAliases,
       formatData,
       tickSuffix,
       tickPrefix,
@@ -82,7 +85,7 @@ const DoubleLine = ({
             ...(showAxisTitles.x && {
               title: {
                 standoff: 20,
-                text: axisTitles.x || x,
+                text: axisTitles.x ||columnNameAliases[x] || x,
               },
             }),
           },
@@ -95,7 +98,7 @@ const DoubleLine = ({
             ...(showAxisTitles.y && y[0] && { 
               title: {
                 standoff: 20,
-                text: axisTitles.y || y[0],
+                text: axisTitles.y || columnNameAliases[y[0]] || y[0],
               },
             }),
           },
@@ -108,7 +111,7 @@ const DoubleLine = ({
             ...(showAxisTitles.y2 && y[1] && { 
               title: {
                 standoff: 20,
-                text: axisTitles.y2 || y[1],
+                text: axisTitles.y2 || columnNameAliases[y[1]] || y[1],
               },
             }),
           },
@@ -147,6 +150,7 @@ DoubleLine.propTypes = {
   ]),
   mode: PropTypes.string,
   onAfterPlot: PropTypes.func,
+  columnNameAliases: PropTypes.object,
   ...plotlyPropTypes,
 }
 
@@ -169,6 +173,7 @@ DoubleLine.defaultProps = {
   hoverText: [],
   mode: 'lines+markers',
   onAfterPlot: () => {},
+  columnNameAliases: {},
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/line/index.js
+++ b/src/components/plotly/line/index.js
@@ -22,6 +22,7 @@ const Line = ({
   onAfterPlot,
   showLineMarkers,
   lineFill,
+  columnNameAliases,
   ...props
 }) => (
   <CustomPlot
@@ -32,6 +33,7 @@ const Line = ({
         data,
         x,
         y,
+        columnNameAliases,
         formatData,
         tickSuffix,
         tickPrefix,
@@ -55,7 +57,7 @@ const Line = ({
         tickprefix: hoverInfo && tickPrefix[0],
         ...(showAxisTitles.x && {
           title: {
-            text: axisTitles.x || x,
+            text: axisTitles.x || columnNameAliases[x] || x,
             standoff: 20,
           },
         }),
@@ -67,7 +69,7 @@ const Line = ({
         tickprefix: hoverInfo && tickPrefix[1],
         ...(showAxisTitles.y && (axisTitles.y || y?.length === 1) && {
           title: {
-            text: axisTitles.y || y[0],
+            text: axisTitles.y || columnNameAliases[y[0]] || y[0],
             standoff: 30,
           },
         }),
@@ -102,6 +104,7 @@ Line.propTypes = {
   onAfterPlot: PropTypes.func,
   showLineMarkers: PropTypes.bool,
   lineFill: PropTypes.bool,
+  columnNameAliases: PropTypes.object,
   ...plotlyPropTypes,
 }
 
@@ -124,6 +127,7 @@ Line.defaultProps = {
   onAfterPlot: () => {},
   showLineMarkers: false,
   lineFill: false,
+  columnNameAliases: {},
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/pie/index.js
+++ b/src/components/plotly/pie/index.js
@@ -23,11 +23,22 @@ const Pie = ({
   hoverText,
   onAfterPlot,
   size,
+  columnNameAliases,
   ...props
 }) => {
+  const { values } = props
+  let _hoverInfo = hoverInfo
+  if (!hoverInfo) {
+    if (values.length === 1) {
+      _hoverInfo = 'label+percent+text'
+    } else {
+      _hoverInfo = 'label+percent+text+name'
+    }
+  }
   const transformedData = useTransformedData({
     type: 'pie',
     data,
+    columnNameAliases,
     extra: {
       textinfo: textinfo ?? getTextInfo({ showPercentage, showLabelName }),
       hole: hole ?? (donut ? 0.4 : 0),
@@ -35,7 +46,7 @@ const Pie = ({
     formatData,
     tickSuffix,
     tickPrefix,
-    hoverInfo: hoverInfo || 'label+percent+text',
+    hoverInfo: _hoverInfo,
     hoverText,
     ...props,
   })
@@ -72,6 +83,7 @@ Pie.propTypes = {
   ]),
   onAfterPlot: PropTypes.func,
   size: PropTypes.number,
+  columnNameAliases: PropTypes.object,
   ...plotlyPropTypes,
 }
 
@@ -88,6 +100,7 @@ Pie.defaultProps = {
   hoverText: '',
   onAfterPlot: () => {},
   size: 0.8,
+  columnNameAliases: {},
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/pyramid-bar/index.js
+++ b/src/components/plotly/pyramid-bar/index.js
@@ -25,6 +25,7 @@ const PyramidBar = ({
   hoverInfo,
   hoverText,
   onAfterPlot,
+  columnNameAliases,
   ...props
 }) => {
   const _data = useTransformedData({
@@ -32,13 +33,14 @@ const PyramidBar = ({
     data,
     x,
     y,
+    columnNameAliases,
     orientation: 'h',
     variant: 'pyramidBar',
     showPercentage,
     sum: getSum(x, data),
     textPosition,
     formatData,
-    hoverInfo,
+    hoverInfo: hoverInfo || 'y+text+name',
     hoverText,
     ...props,
   })
@@ -76,7 +78,6 @@ const PyramidBar = ({
       layout={{
         barmode: 'relative',
         bargap: 0.1,
-        hovermode: false,
         xaxis: {
           showticklabels: showTicks,
           automargin: true,
@@ -88,7 +89,7 @@ const PyramidBar = ({
           tickprefix: tickPrefix[0],
           ...(showAxisTitles.x && {
             title: {
-              text: axisTitles.x,
+              text: axisTitles.x || columnNameAliases[x] || x,
               standoff: 20,
             },
           }),
@@ -102,13 +103,14 @@ const PyramidBar = ({
           tickprefix: tickPrefix[1],
           ...(showAxisTitles.y && {
             title: {
-              text: axisTitles.y || Object.keys(data[0])[0],
+              text: axisTitles.y || columnNameAliases[Object.keys(data[0])[0]] || Object.keys(data[0])[0],
               standoff: 30,
             },
           }),
         },
       }}
       onAfterPlot={onAfterPlot}
+      columnNameAliases={columnNameAliases}
       {...props}
     />
   )
@@ -139,6 +141,7 @@ PyramidBar.propTypes = {
     PropTypes.string,
   ]),
   onAfterPlot: PropTypes.func,
+  columnNameAliases: PropTypes.object,
   ...plotlyPropTypes,
 }
 
@@ -159,9 +162,10 @@ PyramidBar.defaultProps = {
   formatData: {},
   tickSuffix: [],
   tickPrefix: [],
-  hoverInfo: 'all',
+  hoverInfo: '',
   hoverText: '',
   onAfterPlot: () => {},
+  columnNameAliases: {},
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/scatter/index.js
+++ b/src/components/plotly/scatter/index.js
@@ -20,6 +20,7 @@ const Scatter = ({
   hoverInfo,
   hoverText,
   onAfterPlot,
+  columnNameAliases,
   ...props
 }) => (
   <CustomPlot
@@ -30,6 +31,7 @@ const Scatter = ({
         data,
         x,
         y,
+        columnNameAliases,
         formatData,
         tickSuffix,
         tickPrefix,
@@ -49,7 +51,7 @@ const Scatter = ({
         tickprefix: hoverInfo || tickPrefix[0],
         ...(showAxisTitles.x && {
           title: {
-            text: axisTitles.x || x,
+            text: axisTitles.x || columnNameAliases[x] || x,
             standoff: 20,
           },
         }),
@@ -61,7 +63,7 @@ const Scatter = ({
         tickprefix: hoverInfo || tickPrefix[1],
         ...(showAxisTitles.y && (axisTitles.y || y?.length === 1) && {
           title: {
-            text: axisTitles.y || y[0],
+            text: axisTitles.y || columnNameAliases[y[0]] || y[0],
             standoff: 30,
           },
         }),
@@ -101,6 +103,7 @@ Scatter.propTypes = {
     PropTypes.string,
   ]),
   onAfterPlot: PropTypes.func,
+  columnNameAliases: PropTypes.object,
   ...plotlyPropTypes,
 }
 
@@ -120,6 +123,7 @@ Scatter.defaultProps = {
   hoverInfo: '',
   hoverText: '',
   onAfterPlot: () => {},
+  columnNameAliases: {},
   ...plotlyDefaultProps,
 }
 

--- a/src/components/plotly/shared/utils.js
+++ b/src/components/plotly/shared/utils.js
@@ -139,4 +139,20 @@ const getObjectByType = (
   return typeConfig
 }
 
-export { getTextInfo, getAxisTitle, getMaxRange, getSum, getText, getObjectByType, getBarAxisShowTitle }
+const getHoverInfo = ({ cond, value, hoverInfo }) => {
+  if (cond && value) {
+    return value
+  }
+  return hoverInfo
+}
+
+export {
+  getTextInfo,
+  getAxisTitle,
+  getMaxRange,
+  getSum,
+  getText,
+  getObjectByType,
+  getBarAxisShowTitle,
+  getHoverInfo,
+}

--- a/stories/d3/cluster.stories.js
+++ b/stories/d3/cluster.stories.js
@@ -78,7 +78,7 @@ export const Default = (args) => {
     mode: {
       showCommonNodes: args.commonNodes,
       groups: [1, 2],
-      colors: ['#a9ff91', '#4278ff', '#dc91ff']
+      colors: ['#a9ff91', '#4278ff', '#dc91ff'],
     },
     clusterMaxLength: args.clusterMaxLength,
     tooltip: {

--- a/stories/plotly/plotly-bar-line.stories.js
+++ b/stories/plotly/plotly-bar-line.stories.js
@@ -22,33 +22,33 @@ const Template = (args) =>
 export const Default = Template.bind({})
 
 export const LineMarkersAndFill = Template.bind({})
-LineMarkersAndFill.args= {
+LineMarkersAndFill.args = {
   showLineMarkers: true,
   lineFill: true,
 }
 
 export const CustomColors = Template.bind({})
-CustomColors.args= {
+CustomColors.args = {
   y: ['transactions', 'transactions1'],
   y2: ['transactions', 'transactions1'],
   customColors: {
     color1: ['#004C86', '#1F7F79', '#D3A642', '#3175AC'],
-    color2: ['#B24456', '#D3A642']
-  }
+    color2: ['#B24456', '#D3A642'],
+  },
 }
 
 export const CustomBaseColors = Template.bind({})
-CustomBaseColors.args= {
+CustomBaseColors.args = {
   y: ['transactions', 'transactions1'],
   y2: ['transactions', 'transactions1'],
   baseColor: {
     color1: '#004C86',
     color2: '#CF7047',
-  }
+  },
 }
 
 export const MultipleYaxis = Template.bind({})
-MultipleYaxis.args= {
+MultipleYaxis.args = {
   y: ['spend'],
   y2: ['transactions'],
   tickPrefix: ['$'],
@@ -56,11 +56,21 @@ MultipleYaxis.args= {
 }
 
 export const CustomAxisTitles = Template.bind({})
-CustomAxisTitles.args= {
+CustomAxisTitles.args = {
   y: ['spend'],
   y2: ['transactions'],
   tickPrefix: ['$'],
   sharedYAxis: false,
   showAxisTitles: { x: true, y: false, y2: true },
   axisTitles: { x: 'Canadian City', y: 'Custom Spend', y2: 'Custom Transactions' },
+}
+
+export const ColumnNameAliases = Template.bind({})
+ColumnNameAliases.args = {
+  y: ['spend'],
+  y2: ['transactions'],
+  tickPrefix: ['$'],
+  sharedYAxis: false,
+  showAxisTitles: { x: true, y: false, y2: true },
+  columnNameAliases: { spend: 'Spend', transactions: 'New Transactions', city: 'New City' },
 }

--- a/stories/plotly/plotly-bar.stories.js
+++ b/stories/plotly/plotly-bar.stories.js
@@ -40,7 +40,18 @@ const FormattingTemplate = (args) =>
 export const Default = Template.bind({})
 
 export const CustomAxisTitles = Template.bind({})
-CustomAxisTitles.args= { axisTitles: { y: 'Score' } }
+CustomAxisTitles.args = { axisTitles: { y: 'Score' } }
+
+export const ColumnNameAliases = Template.bind({})
+ColumnNameAliases.args = { columnNameAliases: { city: 'City New', stat1: 'Stat 1', stat2: 'Stat 2' } }
+
+export const ColumnNameAliasesInverseDomain = Template.bind({})
+ColumnNameAliasesInverseDomain.args = {
+  columnNameAliases: { city: 'City New', stat1: 'Stat 1', stat2: 'Stat 2' },
+  showAxisTitles: { x: false, y: true },
+  axisTitles: { y: 'Stats (%)' },
+  groupByValue: true,
+}
 
 export const Stacked = Template.bind({})
 Stacked.args = { stacked: true }
@@ -59,8 +70,8 @@ HorizontalStacked.args = {
   axisTitles: { y: 'Impressions' },
 }
 
-export const HorizontalFormatted = FormattingTemplate.bind({})
-HorizontalFormatted.args = { 
+export const HorizontalFormattedData = FormattingTemplate.bind({})
+HorizontalFormattedData.args = {
   orientation: 'h', 
   formatData: { 
     'hh_income_0_50k': formatting,

--- a/stories/plotly/plotly-double-line.stories.js
+++ b/stories/plotly/plotly-double-line.stories.js
@@ -22,7 +22,12 @@ export const Default = Template.bind({})
 Default.args = { tickSuffix: ['%', '%'] }
 
 export const CustomAxisTitles = Template.bind({})
-CustomAxisTitles.args= {
+CustomAxisTitles.args = {
   axisTitles: { x: 'Canadian City', y: 'Dollar Spend (%)', y2: 'Transactions (%)' },
-  tickSuffix: ['%', '%']
+  tickSuffix: ['%', '%'],
+}
+
+export const ColumnNameAliases = Template.bind({})
+ColumnNameAliases.args = {
+  columnNameAliases: { city: 'New City', spend: 'Spend (%)', transactions: 'Transactions (%)' },
 }

--- a/stories/plotly/plotly-line.stories.js
+++ b/stories/plotly/plotly-line.stories.js
@@ -21,7 +21,16 @@ const Template = (args) =>
 export const Default = Template.bind({})
 
 export const CustomAxisTitles = Template.bind({})
-CustomAxisTitles.args= { axisTitles: { x: 'Stat', y: '%' } }
+CustomAxisTitles.args = { axisTitles: { x: 'Stat', y: '%' } }
 
 export const Spline = Template.bind({})
 Spline.args = { spline: true }
+
+export const ColumnNameAliases = Template.bind({})
+ColumnNameAliases.args = { columnNameAliases: { age: 'Age', stat1: 'Stat 1', stat2: 'Stat 2' } }
+
+export const ColumnNameAliasesInverseDomain = Template.bind({})
+ColumnNameAliasesInverseDomain.args = {
+  columnNameAliases: { stat1: 'Stat 1', stat2: 'Stat 2', age: 'Age' },
+  groupByValue: true,
+}

--- a/stories/plotly/plotly-pie.stories.js
+++ b/stories/plotly/plotly-pie.stories.js
@@ -48,7 +48,7 @@ CustomColors.args = {
   customColors: {
     color1: ['#88CCEE', '#CC6677', '#DDCC77', '#477733', '#0F2288'],
     color2: ['#B24456', '#D3A642'],
-  } 
+  },
 }
 
 export const CustomBaseColor = Template.bind({})
@@ -56,5 +56,14 @@ CustomBaseColor.args = {
   baseColor: {
     color1: '#004C86',
     color2: '#CF7047',
-  }
+  },
+}
+
+export const ColumnNameAliases = Template.bind({})
+ColumnNameAliases.args = { columnNameAliases: { stat1: 'Stat 1', stat2: 'Stat 2' } }
+
+export const ColumnNameAliasesInverseDomain = Template.bind({})
+ColumnNameAliasesInverseDomain.args = {
+  columnNameAliases: { stat1: 'Stat 1', stat2: 'Stat 2' },
+  groupByValue: true,
 }

--- a/stories/plotly/plotly-pyramid-bar.stories.js
+++ b/stories/plotly/plotly-pyramid-bar.stories.js
@@ -36,10 +36,13 @@ const Template = (args) =>
 export const Default = Template.bind({})
 
 export const CustomAxisTitles = Template.bind({})
-CustomAxisTitles.args= { axisTitles: { x: 'Count', y: 'Age Group' } }
+CustomAxisTitles.args = { axisTitles: { x: 'Count', y: 'Age Group' } }
 
 export const Percentage = Template.bind({})
 Percentage.args = { showPercentage: true }
 
 export const CustomXaxisTick = Template.bind({})
 CustomXaxisTick.args = { xAxisTick: [1000, 600, 300] }
+
+export const ColumnNameAliases = Template.bind({})
+ColumnNameAliases.args = { columnNameAliases: { man: 'Man', woman: 'Woman' } }

--- a/stories/plotly/plotly-scatter.stories.js
+++ b/stories/plotly/plotly-scatter.stories.js
@@ -21,7 +21,16 @@ const Template = (args) =>
 export const Default = Template.bind({})
 
 export const CustomAxisTitles = Template.bind({})
-CustomAxisTitles.args= { axisTitles: { x: 'Stat', y: 'Score' } }
+CustomAxisTitles.args = { axisTitles: { x: 'Stat', y: 'Score' } }
 
 export const WithLines = Template.bind({})
 WithLines.args = { showLines: true }
+
+export const ColumnNameAliases = Template.bind({})
+ColumnNameAliases.args = { columnNameAliases: { stat1: 'Stat 1', stat2: 'Stat 2', age: 'Age' } }
+
+export const ColumnNameAliasesInverseDomain = Template.bind({})
+ColumnNameAliasesInverseDomain.args = {
+  columnNameAliases: { stat1: 'Stat 1', stat2: 'Stat 2', age: 'Age' },
+  groupByValue: true,
+}


### PR DESCRIPTION
https://www.notion.so/eqproduct/Chart-system-adjust-tooltips-axis-labels-legend-to-use-formatted-column-names-9099a89aa8e648ba938e04f7e5db44c5?pvs=4

**Changes:**

### Plotly charts
- added `columnNameAliases` prop & code logic to format axis titles, tooltip & legend
- added `ColumnNameAliases` & `ColumnNameAliasesInverseDomain` to plotly chart stories
- these changes will address the new changes in [widget-studio](https://github.com/EQWorks/widget-studio/pull/226), where we eliminated using aliases/formatted column names directly in the data, so we avoid changing the data set every time we change column aliases

<img width="1026" alt="Screen Shot 2023-03-24 at 10 25 04 AM" src="https://user-images.githubusercontent.com/41120953/227551993-8baaa354-0a33-4236-8bcd-77bccd264c32.png">

<img width="1026" alt="Screen Shot 2023-03-24 at 10 24 20 AM" src="https://user-images.githubusercontent.com/41120953/227552029-4474f85f-8dd4-42c0-86a0-2955d5418046.png">

<img width="1026" alt="Screen Shot 2023-03-24 at 10 23 59 AM" src="https://user-images.githubusercontent.com/41120953/227552070-36626422-7627-4385-ad30-97651b690db1.png">


**Others:**
- fixed lint warnings for d3 charts

**Stories to test:**
https://60f5a69eddb5b90039b6d17c-eywbhpbmfu.chromatic.com/?path=/story/plotly-bar--column-name-aliases
https://60f5a69eddb5b90039b6d17c-eywbhpbmfu.chromatic.com/?path=/story/plotly-bar--column-name-aliases-inverse-domain

In Widget Studio
https://6139016b390968003a20da5a-dreelduhsd.chromatic.com/?path=/story/editor-mode--dev-pie-4
